### PR TITLE
Add `marginal_map_experiment` CLI tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,5 +66,9 @@ name = "semantic_hash_experiment"
 path = "bin/semantic_hash_experiment.rs"
 
 [[bin]]
+name = "marginal_map_experiment"
+path = "bin/marginal_map_experiment.rs"
+
+[[bin]]
 name = "dump_models"
 path = "bin/dump_models.rs"

--- a/bin/marginal_map_experiment.rs
+++ b/bin/marginal_map_experiment.rs
@@ -1,0 +1,66 @@
+extern crate rsdd;
+
+use std::{collections::HashMap, fs, iter::FromIterator};
+
+use clap::Parser;
+use rand::Rng;
+use rsdd::{
+    builder::{bdd_builder::BddManager, cache::all_app::AllTable},
+    repr::{bdd::BddPtr, cnf::Cnf, var_label::VarLabel, wmc::WmcParams},
+    util::semiring::{RealSemiring, Semiring},
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// input CNF in DIMACS form
+    #[arg(short, long, value_parser)]
+    file: String,
+
+    /// vars to include in marginal map
+    #[arg(short, long, value_parser, action=clap::ArgAction::Append)]
+    vars: Vec<usize>,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let cnf_input = fs::read_to_string(args.file).expect("Should have been able to read the file");
+
+    let cnf = Cnf::from_file(cnf_input);
+    println!("num vars: {}", cnf.num_vars());
+
+    // TODO: allow user to pick varorder
+    let mut mgr = BddManager::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+
+    let bdd = mgr.from_cnf(&cnf);
+
+    if args.vars.is_empty() {
+        panic!("No vars provided. Please provide at least one with -v")
+    }
+
+    let vars = args
+        .vars
+        .iter()
+        .map(|v| VarLabel::new(*v as u64))
+        .collect::<Vec<VarLabel>>();
+
+    let mut rng = rand::thread_rng();
+
+    // TODO: allow user-specified weights or randomized configuration
+    let var_to_val: HashMap<VarLabel, (RealSemiring, RealSemiring)> =
+        HashMap::from_iter((0..cnf.num_vars()).map(|var| {
+            let weight = rng.gen_range(0.0..1.0);
+            (
+                VarLabel::new(var as u64),
+                (RealSemiring(weight), RealSemiring(1.0 - weight)),
+            )
+        }));
+
+    let wmc = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), var_to_val);
+
+    let (probability, partial) = bdd.marginal_map(&vars, mgr.num_vars(), &wmc);
+
+    println!("MAP: {:.2}%", probability);
+    println!("{}", partial);
+}

--- a/src/repr/model.rs
+++ b/src/repr/model.rs
@@ -1,5 +1,7 @@
 //! Models and partial models of logical sentences
 
+use std::fmt::Display;
+
 use super::var_label::{Literal, VarLabel, VarSet};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -112,5 +114,14 @@ impl PartialModel {
             .difference(&other.false_assignments)
             .map(|x| Literal::new(x, false));
         false_diff.chain(true_diff)
+    }
+}
+
+impl Display for PartialModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "T: {}\nF: {}",
+            self.true_assignments, self.false_assignments
+        ))
     }
 }

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -1,6 +1,6 @@
 //! A generic data structure for tracking variable labels throughout the library
 use serde::Serialize;
-use std::fmt;
+use std::fmt::{self, Display};
 
 extern crate quickcheck;
 use bit_set::BitSet;
@@ -100,6 +100,15 @@ impl Serialize for VarSet {
         S: serde::Serializer,
     {
         todo!()
+    }
+}
+
+impl Display for VarSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "{:?}",
+            self.b.iter().map(|v| v).collect::<Vec<usize>>()
+        ))
     }
 }
 


### PR DESCRIPTION
Right now, this is a simple CLI tool that allows arbitrary CNF input, the included variables to map over, and randomly-generated weights per-variable. I'd like to figure out a way for users to specify variable weights instead.

Example usage:

```
$ cargo run --bin marginal_map_experiment --release -- --file cnf/tiny2.cnf -v 1 -v 2 -w 0.5 -w 0.6
num vars: 6
MAP: 25.42%
T: [1]
F: [2]
```

This means:

- we will map with variables `1`, `2` (the argmax term)
- we will set the weights as `0: 0.5`, `1: 0.6` (the `-w`s are processed in-order)
- the rest of the weights (for variables `2-5`) will be randomly generated in `[0.0, 1.0]`