### PR TITLE
Slim down crate size (remove unused deps, move bin/test/WASM deps behind flags)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,10 @@ rand = "0.8.5"
 dimacs = "0.2.0"
 primal = "0.3.0"
 pretty = "0.3.3"
-num = "0.4.0"
 maplit = "1.0.1"
-libc = "0.2"
 quickcheck = "1.0.3"
 serde = { version = "1.0", features = ["derive"] }
-clap = { version = "4.2.1", features = ["derive"] }
 rustc-hash = "1.1.0"
-serde_json = "1.0.81"
 bit-set = "0.5.3"
 segment-tree = "2.0.0"
 dot = "0.1.4"
@@ -30,14 +26,23 @@ bumpalo = "3.11.1"
 petgraph = "0.6.2"
 rsgm = { git = "https://github.com/neuppl/rsgm" }
 rand_chacha = "0.3.1"
-getrandom = { version = "0.2", features = ["js"] } # req for wasm
+getrandom = { version = "0.2", features = ["js"] }
 
+# binary-only features can be optional
+clap = { version = "4.2.1", features = ["derive"], optional = true }
+serde_json = {version = "1.0.81", optional = true}
+
+# WASM-only
 [target.'cfg(target_arch = "wasm32-unknown-unknown")'.dependencies]
 wasm-bindgen = { version = "0.2.84" }
 serde-wasm-bindgen = { version = "0.4" }
 
+# test-only
 [dev-dependencies]
 time-test = "0.2.2"
+
+[features]
+build-binary = ["clap", "serde_json"]
 
 
 [lib]
@@ -59,19 +64,24 @@ rpath = false
 [[bin]]
 name = "one_shot_benchmark"
 path = "bin/one_shot_benchmark.rs"
+required-features = ["build-binary"]
 
 [[bin]]
 name = "bayesian_network_compiler"
 path = "bin/bayesian_network_compiler.rs"
+required-features = ["build-binary"]
 
 [[bin]]
 name = "semantic_hash_experiment"
 path = "bin/semantic_hash_experiment.rs"
+required-features = ["build-binary"]
 
 [[bin]]
 name = "marginal_map_experiment"
 path = "bin/marginal_map_experiment.rs"
+required-features = ["build-binary"]
 
 [[bin]]
 name = "dump_models"
 path = "bin/dump_models.rs"
+required-features = ["build-binary"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "Rust decision diagrams."
 resolver = "2"
 
 [dependencies]
-fnv = "1.0.3"
 rand = "0.8.5"
 dimacs = "0.2.0"
 primal = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ libc = "0.2"
 quickcheck = "1.0.3"
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.2.1", features = ["derive"] }
-criterion = "0.3"
 rustc-hash = "1.1.0"
 serde_json = "1.0.81"
 bit-set = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ quickcheck = "1.0.3"
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.2.1", features = ["derive"] }
 criterion = "0.3"
-rayon = "1.5.3"
 rustc-hash = "1.1.0"
 serde_json = "1.0.81"
 bit-set = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde = { version = "1.0", features = ["derive"] }
 rustc-hash = "1.1.0"
 bit-set = "0.5.3"
 segment-tree = "2.0.0"
-dot = "0.1.4"
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 bumpalo = "3.11.1"
 petgraph = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ petgraph = "0.6.2"
 rsgm = { git = "https://github.com/neuppl/rsgm" }
 rand_chacha = "0.3.1"
 getrandom = { version = "0.2", features = ["js"] } # req for wasm
-wasm-bindgen = "0.2.84"
-serde-wasm-bindgen = "0.4"
+
+[target.'cfg(target_arch = "wasm32-unknown-unknown")'.dependencies]
+wasm-bindgen = { version = "0.2.84" }
+serde-wasm-bindgen = { version = "0.4" }
 
 [dev-dependencies]
 time-test = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Steven Holtzen <sholtzen@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/neuppl/rsdd"
 description = "Rust decision diagrams."
+resolver = "2"
 
 [dependencies]
 fnv = "1.0.3"
@@ -17,7 +18,6 @@ num = "0.4.0"
 maplit = "1.0.1"
 libc = "0.2"
 quickcheck = "1.0.3"
-time-test = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.2.1", features = ["derive"] }
 criterion = "0.3"
@@ -35,6 +35,9 @@ rand_chacha = "0.3.1"
 getrandom = { version = "0.2", features = ["js"] } # req for wasm
 wasm-bindgen = "0.2.84"
 serde-wasm-bindgen = "0.4"
+
+[dev-dependencies]
+time-test = "0.2.2"
 
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde = { version = "1.0", features = ["derive"] }
 rustc-hash = "1.1.0"
 bit-set = "0.5.3"
 segment-tree = "2.0.0"
-tinyvec = { version = "1.6.0", features = ["alloc"] }
 bumpalo = "3.11.1"
 petgraph = "0.6.2"
 rsgm = { git = "https://github.com/neuppl/rsgm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rsdd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Steven Holtzen <sholtzen@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/neuppl/rsdd"
@@ -23,16 +23,17 @@ bumpalo = "3.11.1"
 petgraph = "0.6.2"
 rsgm = { git = "https://github.com/neuppl/rsgm" }
 rand_chacha = "0.3.1"
-getrandom = { version = "0.2", features = ["js"] }
 
 # binary-only features can be optional
 clap = { version = "4.2.1", features = ["derive"], optional = true }
-serde_json = {version = "1.0.81", optional = true}
+serde_json = { version = "1.0.81", optional = true }
 
-# WASM-only
-[target.'cfg(target_arch = "wasm32-unknown-unknown")'.dependencies]
-wasm-bindgen = { version = "0.2.84" }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+serde_json = { version = "1.0.81" }
 serde-wasm-bindgen = { version = "0.4" }
+wasm-bindgen = { version = "0.2.84" }
+
 
 # test-only
 [dev-dependencies]

--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -1,5 +1,4 @@
 extern crate criterion;
-extern crate rayon;
 extern crate rsdd;
 extern crate serde_json;
 

--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -1,5 +1,4 @@
 extern crate rsdd;
-extern crate serde_json;
 
 use clap::Parser;
 use rsdd::builder::bdd_plan::BddPlan;

--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -1,4 +1,3 @@
-extern crate criterion;
 extern crate rsdd;
 extern crate serde_json;
 

--- a/src/builder/bdd_builder.rs
+++ b/src/builder/bdd_builder.rs
@@ -647,7 +647,6 @@ mod tests {
     use crate::util::semiring::{RealSemiring, Semiring};
     use crate::{builder::cache::all_app::AllTable, repr::ddnnf::DDNNFPtr};
     use maplit::*;
-    use num::abs;
 
     use crate::{
         builder::bdd_builder::BddManager,
@@ -713,7 +712,7 @@ mod tests {
         let params =
             WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weights);
         let wmc = r1.wmc(man.get_order(), &params);
-        assert!(abs(wmc.0 - (1.0 - 0.2 * 0.1)) < 0.000001);
+        assert!((wmc.0 - (1.0 - 0.2 * 0.1)).abs() < 0.000001);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate quickcheck;
 extern crate rand_chacha;
 extern crate rustc_hash;
 extern crate segment_tree;
-extern crate time_test;
 extern crate tinyvec;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,7 @@
 extern crate dimacs;
 extern crate dot;
 extern crate fnv;
-extern crate libc;
 extern crate maplit;
-extern crate num;
 extern crate pretty;
 extern crate primal;
 extern crate rand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! Defines exports and the C api
 #![allow(clippy::all)]
 extern crate dimacs;
-extern crate dot;
 extern crate maplit;
 extern crate pretty;
 extern crate primal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,6 @@ pub mod repr;
 pub mod sample;
 pub mod serialize;
 pub mod unique_table;
-#[cfg(feature = "wasm")]
+
+#[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,5 @@ pub mod repr;
 pub mod sample;
 pub mod serialize;
 pub mod unique_table;
+#[cfg(feature = "wasm")]
 pub mod wasm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ extern crate quickcheck;
 extern crate rand_chacha;
 extern crate rustc_hash;
 extern crate segment_tree;
-extern crate tinyvec;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::all)]
 extern crate dimacs;
 extern crate dot;
-extern crate fnv;
 extern crate maplit;
 extern crate pretty;
 extern crate primal;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -561,7 +561,7 @@ mod test_bdd_manager {
             let w2 = mgr.var(vars[2], w[2]);
             let mut conj2 = mgr.and(w0, w1);
             conj2 = mgr.and(conj2, w2);
-            conj2 = mgr.and(conj2, cnf);
+            mgr.and(conj2, cnf);
             let poss_max2 = conj.wmc(mgr.get_order(), &wmc);
             if f64::abs(poss_max2.0 - max) > 0.0001 {
                 pm_check = false;
@@ -578,7 +578,7 @@ mod test_bdd_manager {
             use rsdd::repr::model::PartialModel;
             let n = c1.num_vars();
             // constrain the size, make BDD
-            if n < 5 || n > 8 { return TestResult::discard() }
+            if !(5..=8).contains(&n) { return TestResult::discard() }
             if c1.clauses().len() > 14 { return TestResult::discard() }
             let mut mgr = super::BddManager::<AllTable<BddPtr>>::new_default_order(n);
             let cnf = mgr.from_cnf(&c1);
@@ -676,7 +676,7 @@ mod test_bdd_manager {
             let w2 = mgr.var(decisions[2], w[2]);
             let mut conj2 = mgr.and(w0, w1);
             conj2 = mgr.and(conj2, w2);
-            conj2 = mgr.and(conj2, cnf);
+            mgr.and(conj2, cnf);
             let poss_max2 = conj.wmc(mgr.get_order(), &wmc);
             if f64::abs(poss_max2.1 - max) > 0.0001 {
                 pm_check = false;


### PR DESCRIPTION
The goal of this PR is to reduce the cold-start build time for rsdd. I ran into this frequently as I implemented the benchmark suite.

Big picture, I:

- bump our Cargo resolver/edition to `2` and `2021` respectively
- remove a plethora of now-unused dependencies
- move all of our WASM dependencies behind a `target_arch` flag
- start a partial separation of `lib`, `bin`, and `test` deps
    - moves some binary-only features to a feature flag. this doesn't really work well; ideally, i'd like to put these behind an example?
    - moves `time-test` to a `test-only` dep. couldn't get quickcheck to work properly this time around (that can be a later goal)

For posterity's sake, I removed:

- `criterion` (we weren't using this in `one_shot_benchmark`)
- `dot`
- `fnv`
- `libc`
- `num` (replacing the `abs` call with the `std` one)
- `tinyvec`
- `rayon` (we weren't using this in `one_shot_benchmark`)