### PR TITLE
Re-enable `cargo clippy`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 //! Defines exports and the C api
-#![allow(clippy::all)]
 extern crate dimacs;
 extern crate maplit;
 extern crate pretty;

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -132,7 +132,7 @@ impl<'a> BddBuilder<'a, ROBDDPtr<'a>> for ROBDDBuilder<'a> {
 
     fn ite(&'a self, _f: ROBDDPtr<'a>, g: ROBDDPtr<'a>, _h: ROBDDPtr<'a>) -> ROBDDPtr<'a> {
         let v = g.high();
-        return v.unwrap();
+        v.unwrap()
         // let n : Bdd<ROBDDPtr<'a>> = g.();
         // match n {
         //     Bdd::True => todo!(),

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -68,7 +68,7 @@ pub struct CnfHasher {
 }
 
 impl CnfHasher {
-    pub fn new(clauses: &Vec<Vec<Literal>>, num_vars: usize) -> CnfHasher {
+    pub fn new(clauses: &[Vec<Literal>], num_vars: usize) -> CnfHasher {
         let mut primes = primal::Primes::all();
         let weighted_cnf = clauses
             .iter()
@@ -277,7 +277,7 @@ impl Cnf {
                 let mut clause = clause.clone();
                 clause.sort_by_key(|a| a.get_label().value());
                 clause.dedup();
-                return clause;
+                clause
             })
             .collect();
 
@@ -499,7 +499,6 @@ impl Cnf {
 
     pub fn linear_order(&self) -> VarOrder {
         let v = (0..(self.num_vars))
-            .into_iter()
             .map(|x| VarLabel::new(x as u64))
             .collect();
         VarOrder::new(v)

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -10,7 +10,7 @@ use rand_chacha::ChaCha8Rng;
 /// the constant `P` denotes the size of the field over which the semantic hash will
 /// be computed. For more info, see <https://tr.inf.unibe.ch/pdf/iam-06-001.pdf>
 pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<FiniteField<P>> {
-    let vars: Vec<VarLabel> = (0..num_vars).map(|x| VarLabel::new_usize(x)).collect();
+    let vars: Vec<VarLabel> = (0..num_vars).map(VarLabel::new_usize).collect();
 
     // theoretical guarantee from paper; need to verify more!
     // in "theory", this should be a 0.1% fail rate in one-shot for a BDD.

--- a/src/repr/model.rs
+++ b/src/repr/model.rs
@@ -22,8 +22,8 @@ impl PartialModel {
     pub fn from_vec(assignments: Vec<Option<bool>>) -> PartialModel {
         let mut true_v = VarSet::new_with_num_vars(assignments.len());
         let mut false_v = VarSet::new_with_num_vars(assignments.len());
-        for i in 0..assignments.len() {
-            match assignments[i] {
+        for (i, assignment) in assignments.iter().enumerate() {
+            match assignment {
                 Some(true) => true_v.insert(VarLabel::new_usize(i)),
                 Some(false) => false_v.insert(VarLabel::new_usize(i)),
                 None => (),
@@ -67,11 +67,11 @@ impl PartialModel {
     /// Returns the value of a variable (None if unset)
     pub fn get(&self, label: VarLabel) -> Option<bool> {
         if self.true_assignments.contains(label) {
-            return Some(true);
+            Some(true)
         } else if self.false_assignments.contains(label) {
-            return Some(false);
+            Some(false)
         } else {
-            return None;
+            None
         }
     }
 
@@ -91,11 +91,11 @@ impl PartialModel {
 
     /// True if this is a set variable, false otherwise
     pub fn is_set(&self, label: VarLabel) -> bool {
-        return self.true_assignments.contains(label) || self.false_assignments.contains(label);
+        self.true_assignments.contains(label) || self.false_assignments.contains(label)
     }
 
     /// Produces an iterator of all the assigned literals
-    pub fn assignment_iter<'a>(&'a self) -> impl Iterator<Item = Literal> + 'a {
+    pub fn assignment_iter(&self) -> impl Iterator<Item = Literal> + '_ {
         let false_iter = self
             .false_assignments
             .iter()

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -105,10 +105,7 @@ impl Serialize for VarSet {
 
 impl Display for VarSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!(
-            "{:?}",
-            self.b.iter().map(|v| v).collect::<Vec<usize>>()
-        ))
+        f.write_fmt(format_args!("{:?}", self.b.iter().collect::<Vec<usize>>()))
     }
 }
 
@@ -159,12 +156,12 @@ impl VarSet {
         self.b.intersection(&other.b)
     }
 
-    pub fn remove(&mut self, v: VarLabel) -> () {
+    pub fn remove(&mut self, v: VarLabel) {
         self.b.remove(v.value_usize());
     }
 
     pub fn difference<'a>(&'a self, other: &'a VarSet) -> impl Iterator<Item = VarLabel> + 'a {
-        self.b.difference(&other.b).map(|x| VarLabel::new_usize(x))
+        self.b.difference(&other.b).map(VarLabel::new_usize)
     }
 
     pub fn intersect_varset<'a>(&'a self, other: &'a VarSet) -> VarSet {

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -49,7 +49,7 @@ impl VTree {
                     return true;
                 }
                 s.insert(v.value_usize());
-                return false;
+                false
             }
             BTree::Node((), l, r) => l.check_redundant_vars(s) || r.check_redundant_vars(s),
         }
@@ -269,7 +269,7 @@ pub struct VTreeManager {
     bfs_to_dfs: Vec<usize>,
     /// maps an Sdd VarLabel into its vtree index in the depth-first order
     vtree_idx: Vec<usize>,
-    index_lookup: Vec<Box<VTree>>,
+    index_lookup: Vec<VTree>,
     lca: LeastCommonAncestor,
 }
 
@@ -283,7 +283,7 @@ impl VTreeManager {
         let mut vtree_lookup = vec![0; tree.num_vars()];
         let mut index_lookup = Vec::new();
         for (idx, v) in tree.inorder_dfs_iter().enumerate() {
-            index_lookup.push(Box::new(v.clone()));
+            index_lookup.push(v.clone());
             if v.is_leaf() {
                 vtree_lookup[v.extract_leaf().value_usize()] = idx;
             }

--- a/src/serialize/ser_bdd.rs
+++ b/src/serialize/ser_bdd.rs
@@ -70,6 +70,7 @@ impl BDDSerializer {
 
     pub fn from_bdd(bdd: BddPtr) -> BDDSerializer {
         let mut nodes = Vec::new();
+        #[allow(clippy::mutable_key_type)] // TODO: fix this
         let mut table = HashMap::new();
         let r = BDDSerializer::serialize_helper(bdd, &mut table, &mut nodes);
         BDDSerializer {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -43,6 +43,7 @@ pub fn zero_vec<T>(sz: usize) -> Vec<T> {
 }
 
 /// custom allocation of a non-initialized vector
+#[allow(clippy::uninit_vec)] // intentional!
 pub fn malloc_vec<T>(sz: usize) -> Vec<T> {
     let mut v: Vec<T> = Vec::with_capacity(sz);
     unsafe {

--- a/src/util/semiring.rs
+++ b/src/util/semiring.rs
@@ -77,7 +77,7 @@ impl<const P: u128> FiniteField<P> {
 
     /// computes the additive inverse of self
     pub fn negate(&self) -> FiniteField<P> {
-        return FiniteField::new(P - self.v + 1);
+        FiniteField::new(P - self.v + 1)
     }
 }
 
@@ -192,7 +192,7 @@ pub trait BBAlgebra: Semiring + JoinSemilattice {
 
 impl BBAlgebra for RealSemiring {
     fn choose(&self, arg: &RealSemiring) -> RealSemiring {
-        JoinSemilattice::join(&self, arg)
+        JoinSemilattice::join(self, arg)
     }
 }
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -89,11 +89,11 @@ fn build_vtree(cnf: &Cnf, vtree_type: VTreeType) -> VTree {
         VTreeType::RightLinear => VTree::right_linear(vars),
         VTreeType::EvenSplit(num) => VTree::even_split(vars, num),
         VTreeType::FromDTreeLinear => {
-            let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
+            let dtree = DTree::from_cnf(cnf, &VarOrder::linear_order(cnf.num_vars()));
             VTree::from_dtree(&dtree).unwrap()
         }
         VTreeType::FromDTreeMinFill => {
-            let dtree = DTree::from_cnf(&cnf, &cnf.min_fill_order());
+            let dtree = DTree::from_cnf(cnf, &cnf.min_fill_order());
             VTree::from_dtree(&dtree).unwrap()
         }
     }


### PR DESCRIPTION
Fixes all outstanding `clippy` warnings. Few "real" code changes, but there are some - I did check each of them after-the-fact with our existing tests.

![](https://pyxis.nymag.com/v1/imgs/6fa/06a/f29f0541b8cab85631e2d4c2e10d690511-31-clippy.2x.rsocial.w600.jpg)