### PR TITLE
Remove redundant `SddPtr` functions (`bdd`, `or`, `var`); additional clippy

### DIFF
--- a/src/builder/bdd_plan.rs
+++ b/src/builder/bdd_plan.rs
@@ -16,6 +16,7 @@ pub enum BddPlan {
 }
 
 impl BddPlan {
+    #[allow(clippy::should_implement_trait)] // this is a naming thing; perhaps consider renaming this in the future?
     pub fn not(p: BddPlan) -> Self {
         Self::Not(Box::new(p))
     }

--- a/src/builder/decision_nnf_builder.rs
+++ b/src/builder/decision_nnf_builder.rs
@@ -10,7 +10,6 @@ use crate::{
         unit_prop::{DecisionResult, SATSolver},
     },
 };
-use bumpalo::Bump;
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -214,18 +213,12 @@ impl<'a> DecisionNNFBuilder<'a> {
 
     /// Compute the Boolean function `f | var = value`
     pub fn condition(&'a self, bdd: BddPtr<'a>, lbl: VarLabel, value: bool) -> BddPtr<'a> {
-        let r = self.cond_helper(bdd, lbl, value, &mut Bump::new());
+        let r = self.cond_helper(bdd, lbl, value);
         bdd.clear_scratch();
         r
     }
 
-    fn cond_helper(
-        &'a self,
-        bdd: BddPtr<'a>,
-        lbl: VarLabel,
-        value: bool,
-        alloc: &mut Bump,
-    ) -> BddPtr<'a> {
+    fn cond_helper(&'a self, bdd: BddPtr<'a>, lbl: VarLabel, value: bool) -> BddPtr<'a> {
         if bdd.is_const() {
             bdd
         } else if bdd.var() == lbl {
@@ -242,8 +235,8 @@ impl<'a> DecisionNNFBuilder<'a> {
             }
 
             // recurse on the children
-            let l = self.cond_helper(bdd.low(), lbl, value, alloc);
-            let h = self.cond_helper(bdd.high(), lbl, value, alloc);
+            let l = self.cond_helper(bdd.low(), lbl, value);
+            let h = self.cond_helper(bdd.high(), lbl, value);
             if l == h {
                 if bdd.is_neg() {
                     return l.neg();

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -68,14 +68,6 @@ use super::{
 };
 
 impl<'a> SddPtr<'a> {
-    pub fn or(ptr: &'a SddOr) -> SddPtr<'a> {
-        Reg(ptr)
-    }
-
-    pub fn bdd(ptr: &'a BinarySDD) -> SddPtr<'a> {
-        Self::BDD(ptr)
-    }
-
     /// performs a semantic hash and caches the result on the node
     pub fn cached_semantic_hash<const P: u128>(
         &self,
@@ -142,10 +134,6 @@ impl<'a> SddPtr<'a> {
 
     pub fn is_or(&self) -> bool {
         matches!(self, Compl(_) | Reg(_))
-    }
-
-    pub fn var(lbl: VarLabel, polarity: bool) -> SddPtr<'a> {
-        Var(lbl, polarity)
     }
 
     /// uncomplement a pointer
@@ -537,8 +525,8 @@ fn is_compressed_simple_bdd() {
         1,
     );
     let vtree_manager = VTreeManager::new(vtree);
-    let a = SddPtr::var(VarLabel::new(0), true);
-    let b = SddPtr::var(VarLabel::new(1), false);
+    let a = SddPtr::Var(VarLabel::new(0), true);
+    let b = SddPtr::Var(VarLabel::new(1), false);
     let mut binary_sdd = BinarySDD::new(
         VarLabel::new(2),
         a,
@@ -546,7 +534,7 @@ fn is_compressed_simple_bdd() {
         vtree_manager.get_varlabel_idx(VarLabel::new(2)),
     );
     let binary_sdd_ptr = &mut binary_sdd;
-    let bdd_ptr = SddPtr::bdd(binary_sdd_ptr);
+    let bdd_ptr = SddPtr::BDD(binary_sdd_ptr);
     assert_ne!(a, b);
     assert!(bdd_ptr.is_compressed());
 }
@@ -558,7 +546,7 @@ fn is_compressed_simple_bdd_duplicate() {
         1,
     );
     let vtree_manager = VTreeManager::new(vtree);
-    let a = SddPtr::var(VarLabel::new(0), true);
+    let a = SddPtr::Var(VarLabel::new(0), true);
     let mut binary_sdd = BinarySDD::new(
         VarLabel::new(2),
         a,
@@ -566,7 +554,7 @@ fn is_compressed_simple_bdd_duplicate() {
         vtree_manager.get_varlabel_idx(VarLabel::new(2)),
     );
     let binary_sdd_ptr = &mut binary_sdd;
-    let bdd_ptr = SddPtr::bdd(binary_sdd_ptr);
+    let bdd_ptr = SddPtr::BDD(binary_sdd_ptr);
 
     assert!(!bdd_ptr.is_compressed())
 }
@@ -592,8 +580,8 @@ fn is_trimmed_simple_demorgan() {
         1,
     ));
 
-    let x = SddPtr::var(VarLabel::new(0), true);
-    let y = SddPtr::var(VarLabel::new(3), true);
+    let x = SddPtr::Var(VarLabel::new(0), true);
+    let y = SddPtr::Var(VarLabel::new(3), true);
     let res = man.or(x, y).neg();
     let expected = man.and(x.neg(), y.neg());
 
@@ -621,8 +609,8 @@ fn is_canonical_simple_demorgan() {
         ],
         1,
     ));
-    let x = SddPtr::var(VarLabel::new(0), true);
-    let y = SddPtr::var(VarLabel::new(3), true);
+    let x = SddPtr::Var(VarLabel::new(0), true);
+    let y = SddPtr::Var(VarLabel::new(3), true);
     let res = man.or(x, y).neg();
     let expected = man.and(x.neg(), y.neg());
     assert!(expected.is_canonical());

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -49,7 +49,7 @@ impl<'a> SddOr<'a> {
             self.nodes
                 .iter()
                 .map(|and| and.semantic_hash(vtree, map).value())
-                .fold(0, |accum, elem| accum + elem),
+                .sum(),
         )
     }
 
@@ -172,11 +172,11 @@ impl<'a> Iterator for SddNodeIter<'a> {
             BDD(bdd) | ComplBDD(bdd) => match self.count {
                 0 => {
                     self.count += 1;
-                    Some(SddAnd::new(SddPtr::var(bdd.label(), true), bdd.high()))
+                    Some(SddAnd::new(SddPtr::Var(bdd.label(), true), bdd.high()))
                 }
                 1 => {
                     self.count += 1;
-                    Some(SddAnd::new(SddPtr::var(bdd.label(), false), bdd.low()))
+                    Some(SddAnd::new(SddPtr::Var(bdd.label(), false), bdd.low()))
                 }
                 _ => None,
             },


### PR DESCRIPTION
Clippys are:

- unused `alloc` arg in recursion
- allowing some naming things
- a `.sum`