### PR TITLE
Re-add statistics for SDDs, extra benchmarking

### DIFF
--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -149,12 +149,10 @@ where
             .map(|x| x.ptr.unwrap())
     }
 
-    #[allow(dead_code)]
     pub fn num_nodes(&self) -> usize {
         self.len
     }
 
-    #[allow(dead_code)]
     pub fn hits(&self) -> usize {
         self.hits
     }

--- a/src/builder/sdd/builder.rs
+++ b/src/builder/sdd/builder.rs
@@ -15,6 +15,7 @@ use crate::{repr::cnf::Cnf, repr::logical_expr::LogicalExpr, repr::var_label::Va
 #[derive(Default)]
 pub struct SddBuilderStats {
     pub app_cache_hits: usize,
+    pub app_cache_size: usize,
     pub num_logically_redundant: usize,
     pub num_recursive_calls: usize,
     pub num_compressions: usize,

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -141,6 +141,7 @@ impl<'a> SddBuilder<'a> for CompressionSddBuilder<'a> {
     fn stats(&self) -> super::builder::SddBuilderStats {
         SddBuilderStats {
             app_cache_hits: self.bdd_tbl.borrow().hits() + self.sdd_tbl.borrow().hits(),
+            app_cache_size: self.bdd_tbl.borrow().num_nodes() + self.sdd_tbl.borrow().num_nodes(),
             num_logically_redundant: 0,
             num_recursive_calls: *self.num_recursive_calls.borrow(),
             num_compressions: *self.num_compressions.borrow(),

--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -136,6 +136,7 @@ impl<'a, const P: u128> SddBuilder<'a> for SemanticSddBuilder<'a, P> {
 
         SddBuilderStats {
             app_cache_hits: self.bdd_tbl.borrow().hits() + self.sdd_tbl.borrow().hits(),
+            app_cache_size: self.bdd_tbl.borrow().num_nodes() + self.sdd_tbl.borrow().num_nodes(),
             num_logically_redundant: num_collisions,
             num_recursive_calls: *self.num_recursive_calls.borrow(),
             num_compressions: 0,

--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -29,6 +29,10 @@ pub struct SemanticSddBuilder<'a, const P: u128> {
     app_cache: RefCell<HashMap<u128, SddPtr<'a>>>,
     // semantic hashing
     map: WmcParams<FiniteField<P>>,
+    // stats
+    num_recursive_calls: RefCell<usize>,
+    num_get_or_insert_bdd: RefCell<usize>,
+    num_get_or_insert_sdd: RefCell<usize>,
 }
 
 impl<'a, const P: u128> SddBuilder<'a> for SemanticSddBuilder<'a, P> {
@@ -79,6 +83,7 @@ impl<'a, const P: u128> SddBuilder<'a> for SemanticSddBuilder<'a, P> {
     }
 
     fn get_or_insert_bdd(&'a self, bdd: BinarySDD<'a>) -> SddPtr<'a> {
+        *self.num_get_or_insert_bdd.borrow_mut() += 1;
         let semantic_hash = bdd.semantic_hash(&self.vtree, &self.map);
 
         if let Some(sdd) = self.check_cached_hash_and_neg(semantic_hash) {
@@ -93,6 +98,7 @@ impl<'a, const P: u128> SddBuilder<'a> for SemanticSddBuilder<'a, P> {
     }
 
     fn get_or_insert_sdd(&'a self, or: SddOr<'a>) -> SddPtr<'a> {
+        *self.num_get_or_insert_sdd.borrow_mut() += 1;
         let semantic_hash = or.semantic_hash(&self.vtree, &self.map);
         if let Some(sdd) = self.check_cached_hash_and_neg(semantic_hash) {
             return sdd;
@@ -131,7 +137,15 @@ impl<'a, const P: u128> SddBuilder<'a> for SemanticSddBuilder<'a, P> {
         SddBuilderStats {
             app_cache_hits: self.bdd_tbl.borrow().hits() + self.sdd_tbl.borrow().hits(),
             num_logically_redundant: num_collisions,
+            num_recursive_calls: *self.num_recursive_calls.borrow(),
+            num_compressions: 0,
+            num_get_or_insert_bdd: *self.num_get_or_insert_bdd.borrow(),
+            num_get_or_insert_sdd: *self.num_get_or_insert_sdd.borrow(),
         }
+    }
+
+    fn log_recursive_call(&self) {
+        *self.num_recursive_calls.borrow_mut() += 1
     }
 }
 
@@ -147,7 +161,18 @@ impl<'a, const P: u128> SemanticSddBuilder<'a, P> {
             bdd_tbl: RefCell::new(BackedRobinhoodTable::new()),
             sdd_tbl: RefCell::new(BackedRobinhoodTable::new()),
             map,
+            num_recursive_calls: RefCell::new(0),
+            num_get_or_insert_bdd: RefCell::new(0),
+            num_get_or_insert_sdd: RefCell::new(0),
         }
+    }
+
+    pub fn cached_semantic_hash(&self, sdd: SddPtr) -> FiniteField<P> {
+        sdd.cached_semantic_hash(&self.vtree, &self.map)
+    }
+
+    pub fn map(&self) -> &WmcParams<FiniteField<P>> {
+        &self.map
     }
 
     fn hash_bdd(&self, elem: &BinarySDD) -> u64 {

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -7,7 +7,7 @@ use super::var_label::{Literal, VarLabel};
 
 /// Weighted model counting parameters for a BDD. It primarily is a storage for
 /// the weight on each variable.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WmcParams<T: Semiring> {
     pub zero: T,
     pub one: T,
@@ -68,5 +68,29 @@ impl<T: Semiring + std::ops::Mul<Output = T> + std::ops::Add<Output = T>> WmcPar
     // gives you the weight of `(low, high)` literals for a given VarLabel
     pub fn get_var_weight(&self, label: VarLabel) -> &(T, T) {
         return (self.var_to_val[label.value_usize()]).as_ref().unwrap();
+    }
+}
+
+impl<T: Semiring> Debug for WmcParams<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WmcParams")
+            .field("zero", &self.zero)
+            .field("one", &self.one)
+            .field(
+                "var_to_val",
+                &self
+                    .var_to_val
+                    .iter()
+                    .enumerate()
+                    .map(|(index, val)| {
+                        if let Some((low, high)) = val {
+                            format!("{}: l: {:?}, h: {:?}", index, low, high)
+                        } else {
+                            format!("{}: None", index)
+                        }
+                    })
+                    .collect::<Vec<String>>(),
+            )
+            .finish()
     }
 }

--- a/src/util/semirings/finitefield.rs
+++ b/src/util/semirings/finitefield.rs
@@ -1,9 +1,10 @@
 use super::semiring_traits::*;
+use core::fmt::Debug;
 /// Simple real-number semiring abstraction (all operations standard for reals, abstracted as f64)
 /// a finite-field abstraction. The parameter `p` is the size of the field.
 use std::{fmt::Display, ops};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct FiniteField<const P: u128> {
     v: u128,
 }
@@ -54,12 +55,22 @@ impl<const P: u128> ops::Sub<FiniteField<P>> for FiniteField<P> {
     type Output = FiniteField<P>;
 
     fn sub(self, rhs: FiniteField<P>) -> Self::Output {
-        FiniteField::new(self.v.abs_diff(rhs.v) % P)
+        FiniteField::new(if self.v > rhs.v {
+            self.v - rhs.v
+        } else {
+            rhs.v - self.v
+        })
     }
 }
 
 impl<const P: u128> Display for FiniteField<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.v)
+    }
+}
+
+impl<const P: u128> Debug for FiniteField<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FiniteField({})", self.v)
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -892,11 +892,10 @@ mod test_sdd_builder {
     }
 
     quickcheck! {
-        fn prob_equiv_trivial(c: Cnf, vtree:VTree) -> bool {
+        fn prob_equiv_identical(c: Cnf, vtree:VTree) -> bool {
             let builder1 = CompressionSddBuilder::new(vtree.clone());
             let c1 = builder1.compile_cnf(&c);
 
-            // in this test, compression is still enabled; c2 should be identical to c1
             let builder2 = SemanticSddBuilder::<{ crate::BIG_PRIME }>::new(vtree);
             let c2 = builder2.compile_cnf(&c);
 
@@ -906,6 +905,15 @@ mod test_sdd_builder {
             let h2 = c2.semantic_hash(builder2.get_vtree_manager(), &map);
 
             h1 == h2
+        }
+    }
+
+    quickcheck! {
+        fn prob_equiv_reflexive(c: Cnf, vtree: VTree) -> bool {
+            let builder = SemanticSddBuilder::<{ crate::BIG_PRIME }>::new(vtree);
+            let c = builder.compile_cnf(&c);
+
+            builder.eq(c, c)
         }
     }
 


### PR DESCRIPTION
This PR adds all the stats that I removed in the great traitening/safenings. 

In addition, it:

- slightly changes how finite field's `sub` works, to not use `%`
- adds a new QC test

## some results

Identical final SDDs/allocated nodes, but less recursive calls / get or insert!

```sh
$ cargo run --example semantic_hash_experiment -- -d --file cnf/rand-3-25-100-1.cnf
num vars: 25 | num clauses: 100
from dtree (min-fill)
 
c: 00081 nodes | 007492 nodes alloc | 30398 num recur | 11309 g/i | app cache: 07492 hits, 12.6% recur | 00235 #c | t: 32.919167ms
s: 00081 nodes | 007492 nodes alloc | 29159 num recur | 10965 g/i | app cache: 07492 hits, 11.9% recur | 00000 #c | t: 48.064416ms
```

Worse final SDD, but marginally less nodes allocated / recursive calls / gets or inserts.

```sh
$ cargo run --example semantic_hash_experiment -- -d --file cnf/rand-3-25-100-2.cnf
num vars: 25 | num clauses: 100
from dtree (min-fill)

c: 02179 nodes | 007328 nodes alloc | 28504 num recur | 10158 g/i | app cache: 07328 hits, 9.9% recur | 00358 #c | t: 26.376334ms
s: 03467 nodes | 007317 nodes alloc | 27422 num recur | 09870 g/i | app cache: 07317 hits, 9.2% recur | 00000 #c | t: 44.302917ms
```