### PR TITLE
Batching minor fixes

### DIFF
--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -111,8 +111,7 @@ fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
     }
 
     BenchResult {
-        // num_recursive: builder.stats().num_rec,
-        num_recursive: 0, // TODO: fix
+        num_recursive: builder.stats().num_recursive_calls,
         size: sdd.count_nodes(),
     }
 }
@@ -142,8 +141,7 @@ fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
     }
 
     BenchResult {
-        // num_recursive: builder.stats().num_rec,
-        num_recursive: 0, // TODO: fix
+        num_recursive: builder.stats().num_recursive_calls,
         size: sdd.count_nodes(),
     }
 }

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -237,7 +237,7 @@ impl<'a> BddPtr<'a> {
         match &self {
             Compl(x) | Reg(x) => {
                 if x.data.borrow().is_some() {
-                    x.data.replace(None);
+                    x.data.take();
                     x.low.clear_scratch();
                     x.high.clear_scratch();
                 }
@@ -289,7 +289,7 @@ impl<'a> BddPtr<'a> {
     pub fn set_scratch<T: 'static>(&self, v: T) {
         match self {
             Compl(n) | Reg(n) => {
-                n.data.replace(Some(Box::new(v)));
+                *n.data.borrow_mut() = Some(Box::new(v));
             }
             _ => panic!("attempting to store scratch on constant"),
         }

--- a/src/repr/sdd/binary_sdd.rs
+++ b/src/repr/sdd/binary_sdd.rs
@@ -107,9 +107,8 @@ impl<'a> BinarySDD<'a> {
             .cloned()
     }
 
-    // TODO: this feels wrong?
     pub fn set_scratch<T: 'static>(&self, v: T) {
-        self.scratch.replace(Some(Box::new(v)));
+        *self.scratch.borrow_mut() = Some(Box::new(v));
     }
 
     pub fn clear_scratch(&self) {

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -84,9 +84,8 @@ impl<'a> SddOr<'a> {
             .cloned()
     }
 
-    // TODO: this feels wrong?
     pub fn set_scratch<T: 'static>(&self, v: T) {
-        self.scratch.replace(Some(Box::new(v)));
+        *self.scratch.borrow_mut() = Some(Box::new(v));
     }
 
     pub fn clear_scratch(&self) {

--- a/src/serialize/ser_bdd.rs
+++ b/src/serialize/ser_bdd.rs
@@ -69,7 +69,8 @@ impl BDDSerializer {
 
     pub fn from_bdd(bdd: BddPtr) -> BDDSerializer {
         let mut nodes = Vec::new();
-        #[allow(clippy::mutable_key_type)] // TODO: fix this
+        #[allow(clippy::mutable_key_type)]
+        // this is a false positive, since BddNode's Hash/Ord ignore the scratch.
         let mut table = HashMap::new();
         let r = BDDSerializer::serialize_helper(bdd, &mut table, &mut nodes);
         BDDSerializer {


### PR DESCRIPTION
This PR:

- re-enables recursive call tracking in `one_shot_benchmark`
- fixes some incorrect uses of `RefCell::replace`
- fixes the WASM demo to model count with finite fields