### PR TITLE
Draft: filter out false subs

### DIFF
--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -231,6 +231,24 @@ impl<'a, const P: u128> SemanticSddBuilder<'a, P> {
         }
         None
     }
+
+    pub fn filter_false_subs(&'a self, sdd: SddPtr<'a>) -> SddPtr<'a> {
+        match sdd {
+            SddPtr::Reg(or) => {
+                let or = SddOr::new(
+                    or.nodes
+                        .iter()
+                        .filter(|and| !self.is_false(and.sub()))
+                        .copied()
+                        .collect::<Vec<_>>(),
+                    or.index(),
+                );
+                self.get_or_insert_sdd(or)
+            }
+            SddPtr::Compl(_) => self.filter_false_subs(sdd.neg()).neg(),
+            _ => sdd,
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
This doesn't work because this will always be a cache hit, which means that `get_or_insert` never inserts. Thus, I need to either:

1. force an insertion (and dealloc the old node?)
2. create a new builder?
3. something else

Forcing an insertion is probably a good idea since I will eventually need to do something like that for "picking the best" SDD to store at each allocation decision.