### PR TITLE
Adds `semantic_top_down_experiment`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,5 +66,9 @@ name = "semantic_hash_experiment"
 path = "examples/semantic_hash_experiment.rs"
 
 [[example]]
+name = "semantic_top_down_experiment"
+path = "examples/semantic_top_down_experiment.rs"
+
+[[example]]
 name = "marginal_map_experiment"
 path = "examples/marginal_map_experiment.rs"

--- a/examples/semantic_top_down_experiment.rs
+++ b/examples/semantic_top_down_experiment.rs
@@ -1,0 +1,92 @@
+extern crate rsdd;
+
+use std::{collections::HashMap, fs, time::Instant};
+
+use clap::Parser;
+use rsdd::{
+    builder::decision_nnf::{
+        builder::DecisionNNFBuilder, semantic::SemanticDecisionNNFBuilder,
+        standard::StandardDecisionNNFBuilder,
+    },
+    constants::primes,
+    repr::{
+        bdd::BddPtr, cnf::Cnf, ddnnf::DDNNFPtr, var_label::VarLabel, var_order::VarOrder,
+        wmc::WmcParams,
+    },
+    util::semirings::{realsemiring::RealSemiring, semiring_traits::Semiring},
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// input CNF in DIMACS form
+    #[clap(short, long, value_parser)]
+    file: String,
+}
+
+fn diff_by_wmc(num_vars: usize, order: &VarOrder, std_dnnf: BddPtr, sem_dnnf: BddPtr) -> f64 {
+    let weight_map: HashMap<VarLabel, (RealSemiring, RealSemiring)> =
+        HashMap::from_iter((0..num_vars).map(|x| {
+            (
+                VarLabel::new(x as u64),
+                (RealSemiring(0.3), RealSemiring(0.7)),
+            )
+        }));
+    let params = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+
+    let std_wmc = std_dnnf.wmc(order, &params);
+    let sem_wmc = sem_dnnf.wmc(order, &params);
+
+    f64::abs(std_wmc.0 - sem_wmc.0)
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let cnf_input = fs::read_to_string(args.file).expect("Should have been able to read the file");
+
+    let cnf = Cnf::from_file(cnf_input);
+
+    let linear_order = VarOrder::linear_order(cnf.num_vars());
+
+    let std_builder = StandardDecisionNNFBuilder::new(linear_order.clone());
+
+    let start = Instant::now();
+    let std_dnnf = std_builder.compile_cnf_topdown(&cnf);
+    let std_time = start.elapsed().as_secs_f64();
+
+    let sem_builder =
+        SemanticDecisionNNFBuilder::<{ primes::U64_LARGEST }>::new(linear_order.clone());
+
+    let start = Instant::now();
+    let sem_dnnf = sem_builder.compile_cnf_topdown(&cnf);
+    let sem_time = start.elapsed().as_secs_f64();
+
+    if diff_by_wmc(cnf.num_vars(), &linear_order, std_dnnf, sem_dnnf) > 0.0001 {
+        println!(
+            "error on input {}\n std bdd: {}\nsem bdd: {}",
+            cnf,
+            std_dnnf.to_string_debug(),
+            sem_dnnf.to_string_debug()
+        );
+    }
+
+    println!(
+        "sem/std size ratio: {:.4}x ({} / {})",
+        (sem_dnnf.count_nodes() as f64 / std_dnnf.count_nodes() as f64),
+        sem_dnnf.count_nodes(),
+        std_dnnf.count_nodes()
+    );
+    println!(
+        "sem/std alloc ratio: {:.4}x ({} / {})",
+        (sem_builder.stats().num_nodes_alloc as f64 / std_builder.stats().num_nodes_alloc as f64),
+        sem_builder.stats().num_nodes_alloc,
+        std_builder.stats().num_nodes_alloc
+    );
+    println!(
+        "sem/std time ratio: {:.4}x ({:.4}s / {:.4}s)",
+        (sem_time / std_time),
+        sem_time,
+        std_time
+    );
+}

--- a/src/builder/decision_nnf/builder.rs
+++ b/src/builder/decision_nnf/builder.rs
@@ -14,6 +14,10 @@ use crate::{
 
 use crate::repr::var_label::VarLabel;
 
+pub struct DecisionNNFBuilderStats {
+    pub num_nodes_alloc: usize,
+}
+
 pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
     fn order(&'a self) -> &'a VarOrder;
 
@@ -22,6 +26,10 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
 
     /// counts number of redundant nodes allocated in internal table
     fn num_logically_redundant(&self) -> usize;
+
+    fn stats(&self) -> DecisionNNFBuilderStats;
+
+    // impls
 
     fn conjoin_implied(
         &'a self,

--- a/src/builder/decision_nnf/semantic.rs
+++ b/src/builder/decision_nnf/semantic.rs
@@ -10,7 +10,7 @@ use crate::{
     backing_store::bump_table::BackedRobinhoodTable,
     builder::{
         bdd::robdd::{BddPtr, DDNNFPtr},
-        decision_nnf::builder::DecisionNNFBuilder,
+        decision_nnf::builder::{DecisionNNFBuilder, DecisionNNFBuilderStats},
     },
     repr::bdd::{create_semantic_hash_map, BddNode, VarOrder, WmcParams},
     util::semirings::finitefield::FiniteField,
@@ -62,6 +62,12 @@ impl<'a, const P: u128> DecisionNNFBuilder<'a> for SemanticDecisionNNFBuilder<'a
             }
         }
         num_collisions
+    }
+
+    fn stats(&self) -> DecisionNNFBuilderStats {
+        DecisionNNFBuilderStats {
+            num_nodes_alloc: self.compute_table.borrow().num_nodes(),
+        }
     }
 }
 

--- a/src/builder/decision_nnf/standard.rs
+++ b/src/builder/decision_nnf/standard.rs
@@ -4,7 +4,7 @@ use crate::{
     backing_store::bump_table::BackedRobinhoodTable,
     builder::{
         bdd::robdd::{BddPtr, DDNNFPtr},
-        decision_nnf::builder::DecisionNNFBuilder,
+        decision_nnf::builder::{DecisionNNFBuilder, DecisionNNFBuilderStats},
     },
     constants::primes,
     repr::bdd::{create_semantic_hash_map, BddNode, VarOrder},
@@ -49,6 +49,12 @@ impl<'a> DecisionNNFBuilder<'a> for StandardDecisionNNFBuilder<'a> {
             }
         }
         num_collisions
+    }
+
+    fn stats(&self) -> DecisionNNFBuilderStats {
+        DecisionNNFBuilderStats {
+            num_nodes_alloc: self.compute_table.borrow().num_nodes(),
+        }
     }
 }
 

--- a/src/repr/var_order.rs
+++ b/src/repr/var_order.rs
@@ -4,6 +4,7 @@
 
 use crate::repr::var_label::VarLabel;
 use crate::util;
+use std::fmt::Display;
 use std::slice::Iter;
 
 use super::bdd::BddPtr;
@@ -238,6 +239,12 @@ impl VarOrder {
             .take(high_level - low_level)
             .rev()
             .map(|x| VarLabel::new_usize(*x))
+    }
+}
+
+impl Display for VarOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self.pos_to_var))
     }
 }
 


### PR DESCRIPTION
This PR adds a new example file that compiles a CNF with the semantic/standard top-down approaches, and compares size/time/nodes allocated. It defaults to a linear order, but can search over random ones with `-o`.

Example usage:

```sh
$ cargo run --example semantic_top_down_experiment -- -f cnf/rand-3-37-75-1.cnf
sem/std size ratio: 0.7991x (27230 / 34074)
sem/std alloc ratio: 0.8423x (28701 / 34074)
sem/std time ratio: 1.0293x (0.3909s / 0.3798s)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/blif/cm152a.blif.cnf -o 500
...
=== AVG, n = 500 ===
sem/std size ratio: 0.96x (164 / 170)
```

Other than writing the script, I also added a `DecisionNNFBuilderStats` struct to expose the allocated node count.

## random varorder results

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/rand-3-25-75-2.cnf -o 200
=== AVG, n = 200 ===
sem/std size ratio: 0.81x (1700 / 2093)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/s298.cnf -o 100
...
=== AVG, n = 100 ===
sem/std size ratio: 0.95x (125845 / 132154)
```

## linear order results

### positive results

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/rand-3-25-75-1.cnf 
sem/std size ratio: 0.8125x (1274 / 1568)
sem/std alloc ratio: 0.8948x (1403 / 1568)
sem/std time ratio: 0.9382x (0.0214s / 0.0228s)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/rand-3-37-75-4.cnf 
sem/std size ratio: 0.8641x (94889 / 109813)
sem/std alloc ratio: 0.9208x (101118 / 109813)
sem/std time ratio: 1.0687x (1.3515s / 1.2646s)
```

### little/no benefit

Some of the CNFs have little to no benefit. For example, `c8.cnf`:

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/c8.cnf
sem/std size ratio: 1.0000x (33972633 / 33972642)
sem/std alloc ratio: 1.0000x (33972633 / 33972642)
sem/std time ratio: 1.2373x (224.5690s / 181.5022s)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/50-10-1-q.cnf 
sem/std size ratio: 1.0000x (37429 / 37430)
sem/std alloc ratio: 1.0000x (37429 / 37430)
sem/std time ratio: 1.0083x (0.6820s / 0.6764s)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/s298.cnf 
sem/std size ratio: 1.0000x (24770 / 24770)
sem/std alloc ratio: 1.0000x (24770 / 24770)
sem/std time ratio: 1.1173x (0.1165s / 0.1043s)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/s344.cnf 
sem/std size ratio: 1.0000x (6371265 / 6371266)
sem/std alloc ratio: 1.0000x (6371265 / 6371266)
sem/std time ratio: 1.1723x (42.1602s / 35.9632s)
```

```
$ cargo run --example semantic_top_down_experiment -- -f cnf/blif/my_adder.blif.cnf 
sem/std size ratio: 0.9714x (4456382 / 4587447)
sem/std alloc ratio: 0.9929x (4554680 / 4587447)
sem/std time ratio: 1.1545x (33.9179s / 29.3798s)
```