### PR TITLE
`WmcParams`: cleaner constructors and doctests

### DIFF
--- a/examples/bayesian_network_compiler.rs
+++ b/examples/bayesian_network_compiler.rs
@@ -93,7 +93,7 @@ impl BayesianNetworkCNF {
         BayesianNetworkCNF {
             cnf: Cnf::new(clauses),
             indicators,
-            params: WmcParams::new_with_default(RealSemiring(0.0), RealSemiring(1.0), wmc_params),
+            params: WmcParams::new(wmc_params),
         }
     }
 

--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -11,7 +11,6 @@ use rsdd::{
     },
     repr::{bdd::BddPtr, cnf::Cnf, var_label::VarLabel, wmc::WmcParams},
     util::semirings::RealSemiring,
-    util::semirings::Semiring,
 };
 
 #[derive(Parser, Debug)]
@@ -80,7 +79,7 @@ fn main() {
 
     let var_to_val = gen_all_weights(&args.weights, builder.num_vars());
 
-    let wmc = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), var_to_val);
+    let wmc = WmcParams::new(var_to_val);
 
     let (probability, partial) = bdd.marginal_map(&vars, builder.num_vars(), &wmc);
 

--- a/examples/semantic_top_down_experiment.rs
+++ b/examples/semantic_top_down_experiment.rs
@@ -12,7 +12,7 @@ use rsdd::{
         bdd::BddPtr, cnf::Cnf, ddnnf::DDNNFPtr, var_label::VarLabel, var_order::VarOrder,
         wmc::WmcParams,
     },
-    util::semirings::{RealSemiring, Semiring},
+    util::semirings::RealSemiring,
 };
 
 use rand::seq::SliceRandom;
@@ -38,7 +38,7 @@ fn diff_by_wmc(num_vars: usize, order: &VarOrder, std_dnnf: BddPtr, sem_dnnf: Bd
                 (RealSemiring(0.3), RealSemiring(0.7)),
             )
         }));
-    let params = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+    let params = WmcParams::new(weight_map);
 
     let std_wmc = std_dnnf.wmc(order, &params);
     let sem_wmc = sem_dnnf.wmc(order, &params);

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -287,7 +287,6 @@ mod tests {
     use crate::builder::BottomUpBuilder;
     use crate::repr::wmc::WmcParams;
     use crate::util::semirings::RealSemiring;
-    use crate::util::semirings::Semiring;
     use crate::{builder::cache::all_app::AllTable, repr::ddnnf::DDNNFPtr};
     use maplit::*;
 
@@ -352,8 +351,7 @@ mod tests {
         let r1 = builder.or(v1, v2);
         let weights = hashmap! {VarLabel::new(0) => (RealSemiring(0.2), RealSemiring(0.8)),
         VarLabel::new(1) => (RealSemiring(0.1), RealSemiring(0.9))};
-        let params =
-            WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weights);
+        let params = WmcParams::new(weights);
         let wmc = r1.wmc(builder.get_order().borrow(), &params);
         assert!((wmc.0 - (1.0 - 0.2 * 0.1)).abs() < 0.000001);
     }
@@ -561,7 +559,7 @@ mod tests {
         VarLabel::new(1) => (RealSemiring(1.0), RealSemiring(1.0)),
         VarLabel::new(2) => (RealSemiring(0.8), RealSemiring(0.2)),
         VarLabel::new(3) => (RealSemiring(0.7), RealSemiring(0.3)) };
-        let wmc = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), map);
+        let wmc = WmcParams::new(map);
         let iff1 = builder.iff(x, f1);
         let iff2 = builder.iff(y, f2);
         let obs = builder.or(x, y);

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -457,7 +457,7 @@ fn sdd_wmc1() {
         1,
     );
     let builder = CompressionSddBuilder::new(vtree);
-    let mut wmc_map = crate::repr::wmc::WmcParams::new(RealSemiring(0.0), RealSemiring(1.0));
+    let mut wmc_map = crate::repr::wmc::WmcParams::new_with_no_associations();
     let x = SddPtr::Var(VarLabel::new(0), true);
     wmc_map.set_weight(VarLabel::new(0), RealSemiring(1.0), RealSemiring(1.0));
     let y = SddPtr::Var(VarLabel::new(1), true);

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -457,7 +457,7 @@ fn sdd_wmc1() {
         1,
     );
     let builder = CompressionSddBuilder::new(vtree);
-    let mut wmc_map = crate::repr::wmc::WmcParams::new_with_no_associations();
+    let mut wmc_map = crate::repr::wmc::WmcParams::default();
     let x = SddPtr::Var(VarLabel::new(0), true);
     wmc_map.set_weight(VarLabel::new(0), RealSemiring(1.0), RealSemiring(1.0));
     let y = SddPtr::Var(VarLabel::new(1), true);

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -732,12 +732,5 @@ fn test_cnf_wmc() {
         VarLabel::new(0) => (FiniteField::new(1), FiniteField::new(1)),
         VarLabel::new(1) => (FiniteField::new(1), FiniteField::new(1)),
     };
-    assert_eq!(
-        cnf.wmc(&WmcParams::new_with_default(
-            FiniteField::zero(),
-            FiniteField::one(),
-            weights
-        )),
-        FiniteField::new(3)
-    );
+    assert_eq!(cnf.wmc(&WmcParams::new(weights)), FiniteField::new(3));
 }

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -37,7 +37,7 @@ pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<Fin
         map.insert(var, value);
     }
 
-    WmcParams::new_with_default(FiniteField::zero(), FiniteField::one(), map)
+    WmcParams::new(map)
 }
 
 use super::{
@@ -97,24 +97,16 @@ pub trait DDNNFPtr<'a>: Clone + Debug + PartialEq + Eq + Hash + Copy {
     }
 
     fn evaluate(&self, o: &Self::Order, instantations: &[bool]) -> bool {
-        fn gen_bs_mappings(
-            instantations: &[bool],
-        ) -> HashMap<VarLabel, (BooleanSemiring, BooleanSemiring)> {
-            HashMap::from_iter(instantations.iter().enumerate().map(|(index, polarity)| {
-                (
-                    VarLabel::new(index as u64),
-                    (BooleanSemiring(!polarity), BooleanSemiring(*polarity)),
-                )
-            }))
-        }
-
         self.wmc(
             o,
-            &WmcParams::new_with_default(
-                BooleanSemiring::zero(),
-                BooleanSemiring::one(),
-                gen_bs_mappings(instantations),
-            ),
+            &WmcParams::new(HashMap::from_iter(instantations.iter().enumerate().map(
+                |(index, polarity)| {
+                    (
+                        VarLabel::new(index as u64),
+                        (BooleanSemiring(!polarity), BooleanSemiring(*polarity)),
+                    )
+                },
+            ))),
         )
         .0
     }

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -51,24 +51,6 @@ impl<T: Semiring> WmcParams<T> {
         }
     }
 
-    /// Parametrize a weighted model count (over a semiring) with no default assocations;
-    /// requires weights to be set before performing the count.
-    /// ```
-    /// use rsdd::repr::wmc::WmcParams;
-    /// use rsdd::util::semirings::{RealSemiring, FiniteField};
-    ///
-    /// let params = WmcParams::<RealSemiring>::new_with_no_associations();
-    ///
-    /// let params = WmcParams::<FiniteField<2>>::new_with_no_associations();
-    /// ```
-    pub fn new_with_no_associations() -> WmcParams<T> {
-        WmcParams {
-            zero: T::zero(),
-            one: T::one(),
-            var_to_val: Vec::new(),
-        }
-    }
-
     /// get the weight of an asignment
     /// ```
     /// use rsdd::repr::var_label::{Literal, VarLabel};
@@ -175,5 +157,25 @@ impl<T: Semiring> Debug for WmcParams<T> {
                     .collect::<Vec<String>>(),
             )
             .finish()
+    }
+}
+
+impl<T: Semiring> Default for WmcParams<T> {
+    /// Parametrize a weighted model count (over a semiring) with no default assocations;
+    /// requires weights to be set before performing the count.
+    /// ```
+    /// use rsdd::repr::wmc::WmcParams;
+    /// use rsdd::util::semirings::{RealSemiring, FiniteField};
+    ///
+    /// let params = WmcParams::<RealSemiring>::default();
+    ///
+    /// let params = WmcParams::<FiniteField<2>>::default();
+    /// ```
+    fn default() -> Self {
+        WmcParams {
+            zero: T::zero(),
+            one: T::one(),
+            var_to_val: Vec::new(),
+        }
     }
 }

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -12,7 +12,6 @@ use crate::repr::wmc::WmcParams;
 use crate::repr::{cnf::Cnf, var_label::VarLabel, vtree::VTree};
 use crate::serialize::{BDDSerializer, SDDSerializer, VTreeSerializer};
 use crate::util::semirings::FiniteField;
-use crate::util::semirings::Semiring;
 use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Deserialize)]
@@ -101,7 +100,7 @@ pub fn demo_model_count_sdd(cnf_input: String) -> Result<JsValue, JsValue> {
     let sdd = builder.compile_cnf(&cnf);
 
     let mut params: WmcParams<FiniteField<{ primes::U32_TINY }>> =
-        WmcParams::new(FiniteField::zero(), FiniteField::one());
+        WmcParams::new_with_no_associations();
 
     for v in 0..builder.get_vtree_manager().num_vars() + 1 {
         params.set_weight(

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -99,8 +99,7 @@ pub fn demo_model_count_sdd(cnf_input: String) -> Result<JsValue, JsValue> {
     let builder = CompressionSddBuilder::new(vtree.clone());
     let sdd = builder.compile_cnf(&cnf);
 
-    let mut params: WmcParams<FiniteField<{ primes::U32_TINY }>> =
-        WmcParams::new_with_no_associations();
+    let mut params: WmcParams<FiniteField<{ primes::U32_TINY }>> = WmcParams::default();
 
     for v in 0..builder.get_vtree_manager().num_vars() + 1 {
         params.set_weight(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -461,7 +461,7 @@ mod test_bdd_builder {
             let builder2 = StandardDecisionNNFBuilder::new(order);
             let dnnf = builder2.compile_cnf_topdown(&c1);
 
-            let bddwmc = super::repr::wmc::WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+            let bddwmc = super::repr::wmc::WmcParams::new(weight_map);
             let bddres = cnf1.wmc(builder.get_order(),  &bddwmc);
             let dnnfres = dnnf.wmc(builder.get_order(), &bddwmc);
             let eps = f64::abs(bddres.0 - dnnfres.0) < 0.0001;
@@ -482,7 +482,7 @@ mod test_bdd_builder {
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
 
-            let bddwmc = super::repr::wmc::WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+            let bddwmc = super::repr::wmc::WmcParams::new(weight_map);
             let cnf1 = builder1.compile_cnf(&c1);
             let cnf2 = builder2.compile_cnf(&c1);
             let wmc1 = cnf1.wmc(builder1.get_order(), &bddwmc);
@@ -508,7 +508,7 @@ mod test_bdd_builder {
                || !c1.var_in_cnf(VarLabel::new(4)) {
                 return TestResult::discard()
             }
-            let wmc = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+            let wmc = WmcParams::new(weight_map);
 
             let (marg_prob, marg_assgn) = cnf.marginal_map(&vars, builder.num_vars(), &wmc);
             let (marg_prob_bb, marg_assgn_bb) = cnf.bb(&vars, builder.num_vars(), &wmc);
@@ -617,7 +617,7 @@ mod test_bdd_builder {
 
             // set up wmc, run meu
             let vars = decisions.clone();
-            let wmc = WmcParams::new_with_default(ExpectedUtility::zero(), ExpectedUtility::one(), weight_map);
+            let wmc = WmcParams::new(weight_map);
 
             let (meu , meu_assgn) = cnf.meu(&vars, builder.num_vars(), &wmc);
             let (meu_bb, meu_assgn_bb) = cnf.bb(&vars, builder.num_vars(), &wmc);
@@ -1116,7 +1116,7 @@ mod test_dnnf_builder {
         repr::{
             cnf::Cnf, ddnnf::DDNNFPtr, var_label::VarLabel, var_order::VarOrder, wmc::WmcParams,
         },
-        util::semirings::{RealSemiring, Semiring},
+        util::semirings::RealSemiring,
     };
 
     #[derive(Clone, Debug)]
@@ -1179,7 +1179,7 @@ mod test_dnnf_builder {
 
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
-            let params = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+            let params = WmcParams::new(weight_map);
 
             let std_wmc = std_dnnf.wmc(&linear_order, &params);
             let sem_wmc = sem_dnnf.wmc(&linear_order, &params);
@@ -1207,7 +1207,7 @@ mod test_dnnf_builder {
 
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..cnf.num_vars()).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
-            let params = WmcParams::new_with_default(RealSemiring::zero(), RealSemiring::one(), weight_map);
+            let params = WmcParams::new(weight_map);
 
             let std_wmc = std_dnnf.wmc(&order, &params);
             let sem_wmc = sem_dnnf.wmc(&order, &params);


### PR DESCRIPTION
This PR does a handful of things:

- for both `::new` functions, `WmcParams` now uses the `::zero` and `::one` provided by the `Semiring` implementation, which is already a trait bound on `WmcParams<T>`
    - this means that you don't need to explicitly call `::zero` and `::one`, which feels both frustrating and a potential footgun
    - also allows users to not have to import the `Semiring` trait itself!
- have renamed the two constructors (to better align with Rust naming conventions):
    - the old `::new_with_default()` has now become `::new()`, omitting the `zero` and `one` args
    - the old `::new` has now become `::default()` (for the `Default` trait), omitting the `zero` and `one` args
- all functions now have doctests :)