### PR TITLE
Cleanup dependencies (`time-test`, `rsgm`, `maplit`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ rand = "0.8.5"
 dimacs = "0.2.0"
 primal = "0.3.0"
 pretty = "0.3.3"
-maplit = "1.0.1"
 quickcheck = "1.0.3"
 serde = { version = "1.0", features = ["derive"] }
 rustc-hash = "1.1.0"
@@ -21,7 +20,6 @@ bit-set = "0.5.3"
 segment-tree = "2.0.0"
 bumpalo = "3.11.1"
 petgraph = "0.6.2"
-rsgm = { git = "https://github.com/neuppl/rsgm" }
 rand_chacha = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -30,11 +28,10 @@ serde_json = { version = "1.0.81" }
 serde-wasm-bindgen = { version = "0.4" }
 wasm-bindgen = { version = "0.2.84" }
 
-
-# test-only
+# example/test-only
 [dev-dependencies]
-time-test = "0.2.2"
 clap = { version = "4.2.1", features = ["derive"] }
+rsgm = { git = "https://github.com/neuppl/rsgm" }
 serde_json = { version = "1.0.81" }
 
 [lib]

--- a/examples/bayesian_network_compiler.rs
+++ b/examples/bayesian_network_compiler.rs
@@ -1,14 +1,10 @@
-#![allow(clippy::all)]
-extern crate rsdd;
-extern crate rsgm;
-
-use crate::rsdd::builder::BottomUpBuilder;
 use clap::Parser;
 use rsdd::builder::bdd::BddBuilder;
 use rsdd::builder::cache::all_app::AllTable;
 use rsdd::builder::decision_nnf::DecisionNNFBuilder;
 use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};
+use rsdd::builder::BottomUpBuilder;
 use rsdd::repr::bdd::BddPtr;
 use rsdd::repr::ddnnf::DDNNFPtr;
 use rsdd::repr::dtree::DTree;
@@ -79,8 +75,8 @@ impl BayesianNetworkCNF {
                     indic_vec.push(new_indic);
 
                     println!("{:?} <=> {:?}", cur_param, indic_vec);
-                    let mut imp1 = implies(&vec![Literal::new(cur_param, true)], &indic_vec);
-                    let mut imp2 = implies(&indic_vec, &vec![Literal::new(cur_param, true)]);
+                    let mut imp1 = implies(&[Literal::new(cur_param, true)], &indic_vec);
+                    let mut imp2 = implies(&indic_vec, &[Literal::new(cur_param, true)]);
                     clauses.append(&mut imp1);
                     clauses.append(&mut imp2);
                 }
@@ -131,7 +127,7 @@ struct Args {
 }
 
 /// construct a CNF for the two TERMS (i.e., conjunctions of literals) t1 => t2
-fn implies(t1: &Vec<Literal>, t2: &Vec<Literal>) -> Vec<Vec<Literal>> {
+fn implies(t1: &[Literal], t2: &[Literal]) -> Vec<Vec<Literal>> {
     let mut r: Vec<Vec<Literal>> = Vec::new();
     // negate the lhs
     let lhs: Vec<Literal> = t1

--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -1,5 +1,3 @@
-extern crate rsdd;
-
 use std::{collections::HashMap, fs};
 
 use clap::Parser;

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -1,5 +1,3 @@
-extern crate rsdd;
-
 use clap::Parser;
 use rsdd::builder::bdd::BddBuilder;
 use rsdd::builder::bdd::RobddBuilder;

--- a/examples/semantic_hash_experiment.rs
+++ b/examples/semantic_hash_experiment.rs
@@ -1,5 +1,3 @@
-extern crate rsdd;
-
 use clap::Parser;
 use rsdd::{
     builder::{

--- a/examples/semantic_top_down_experiment.rs
+++ b/examples/semantic_top_down_experiment.rs
@@ -1,5 +1,3 @@
-extern crate rsdd;
-
 use std::{collections::HashMap, fs, time::Instant};
 
 use clap::Parser;

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -282,13 +282,13 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
 mod tests {
 
     use std::borrow::Borrow;
+    use std::collections::HashMap;
 
     use crate::builder::bdd::builder::BddBuilder;
     use crate::builder::BottomUpBuilder;
     use crate::repr::wmc::WmcParams;
     use crate::util::semirings::RealSemiring;
     use crate::{builder::cache::all_app::AllTable, repr::ddnnf::DDNNFPtr};
-    use maplit::*;
 
     use crate::{
         builder::bdd::robdd::RobddBuilder,
@@ -349,8 +349,10 @@ mod tests {
         let v1 = builder.var(VarLabel::new(0), true);
         let v2 = builder.var(VarLabel::new(1), true);
         let r1 = builder.or(v1, v2);
-        let weights = hashmap! {VarLabel::new(0) => (RealSemiring(0.2), RealSemiring(0.8)),
-        VarLabel::new(1) => (RealSemiring(0.1), RealSemiring(0.9))};
+        let weights = HashMap::from_iter([
+            (VarLabel::new(0), (RealSemiring(0.2), RealSemiring(0.8))),
+            (VarLabel::new(1), (RealSemiring(0.1), RealSemiring(0.9))),
+        ]);
         let params = WmcParams::new(weights);
         let wmc = r1.wmc(builder.get_order().borrow(), &params);
         assert!((wmc.0 - (1.0 - 0.2 * 0.1)).abs() < 0.000001);
@@ -555,10 +557,14 @@ mod tests {
         let y = builder.var(VarLabel::new(1), true);
         let f1 = builder.var(VarLabel::new(2), true);
         let f2 = builder.var(VarLabel::new(3), true);
-        let map = hashmap! { VarLabel::new(0) => (RealSemiring(1.0), RealSemiring(1.0)),
-        VarLabel::new(1) => (RealSemiring(1.0), RealSemiring(1.0)),
-        VarLabel::new(2) => (RealSemiring(0.8), RealSemiring(0.2)),
-        VarLabel::new(3) => (RealSemiring(0.7), RealSemiring(0.3)) };
+
+        let map = HashMap::from_iter([
+            (VarLabel::new(0), (RealSemiring(1.0), RealSemiring(1.0))),
+            (VarLabel::new(1), (RealSemiring(1.0), RealSemiring(1.0))),
+            (VarLabel::new(2), (RealSemiring(0.8), RealSemiring(0.2))),
+            (VarLabel::new(3), (RealSemiring(0.7), RealSemiring(0.3))),
+        ]);
+
         let wmc = WmcParams::new(map);
         let iff1 = builder.iff(x, f1);
         let iff2 = builder.iff(y, f2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! Defines exports and the C api
 extern crate dimacs;
-extern crate maplit;
 extern crate pretty;
 extern crate primal;
 extern crate rand;

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -715,7 +715,7 @@ impl fmt::Display for Cnf {
 fn test_cnf_wmc() {
     use crate::constants::primes;
     use crate::util::semirings::FiniteField;
-    use maplit::*;
+    use std::collections::HashMap;
 
     let v = vec![vec![
         Literal::new(VarLabel::new(0), true),
@@ -728,9 +728,9 @@ fn test_cnf_wmc() {
             FiniteField<{ primes::U32_TINY }>,
             FiniteField<{ primes::U32_TINY }>,
         ),
-    > = hashmap! {
-        VarLabel::new(0) => (FiniteField::new(1), FiniteField::new(1)),
-        VarLabel::new(1) => (FiniteField::new(1), FiniteField::new(1)),
-    };
+    > = HashMap::from_iter([
+        (VarLabel::new(0), (FiniteField::new(1), FiniteField::new(1))),
+        (VarLabel::new(1), (FiniteField::new(1), FiniteField::new(1))),
+    ]);
     assert_eq!(cnf.wmc(&WmcParams::new(weights)), FiniteField::new(3));
 }


### PR DESCRIPTION
Changes in this PR:

- crates:
    - remove unused `time-test`
    - move `rsgm` to test-only (only used in bayesian compiler)
    - remove `maplit` since we only use it for a trivial macro
- code:
    - remove useless `extern`
    - fix clippy in bayesian compiler