### PR TITLE
Consistent import formatting

### DIFF
--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -1,13 +1,13 @@
 //! A unique table based on a bump allocator and robin-hood hashing
 //! this is the primary unique table for storing all nodes
 
-use super::UniqueTable;
+use crate::{backing_store::UniqueTable, util::*};
 use bumpalo::Bump;
 use rustc_hash::FxHasher;
-use std::hash::{Hash, Hasher};
-use std::mem;
-
-use crate::util::*;
+use std::{
+    hash::{Hash, Hasher},
+    mem,
+};
 
 /// The load factor of the table, i.e. how full the table will be when it
 /// automatically resizes

--- a/src/builder/bdd/builder.rs
+++ b/src/builder/bdd/builder.rs
@@ -1,19 +1,16 @@
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-
-use crate::plan::bdd_plan::BddPlan;
-use crate::repr::bdd::BddNode;
-use crate::repr::cnf::Cnf;
-use crate::repr::logical_expr::LogicalExpr;
-use crate::repr::model::PartialModel;
-
-use crate::builder::BottomUpBuilder;
-
-use crate::repr::bdd::BddPtr;
-use crate::repr::ddnnf::DDNNFPtr;
-use crate::repr::var_label::VarLabel;
-
-use super::CompiledCNF;
+use crate::{
+    builder::{bdd::CompiledCNF, BottomUpBuilder},
+    plan::bdd_plan::BddPlan,
+    repr::{
+        bdd::{BddNode, BddPtr},
+        cnf::Cnf,
+        ddnnf::DDNNFPtr,
+        logical_expr::LogicalExpr,
+        model::PartialModel,
+        var_label::VarLabel,
+    },
+};
+use std::{cmp::Ordering, collections::BinaryHeap};
 
 pub trait BddBuilder<'a>: BottomUpBuilder<'a, BddPtr<'a>> {
     fn less_than(&self, a: VarLabel, b: VarLabel) -> bool;

--- a/src/builder/bdd/mod.rs
+++ b/src/builder/bdd/mod.rs
@@ -1,6 +1,5 @@
-use std::cmp::Ordering;
-
 use crate::repr::{bdd::BddPtr, var_label::VarLabel};
+use std::cmp::Ordering;
 
 mod builder;
 mod robdd;

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -1,22 +1,19 @@
-use crate::backing_store::BackedRobinhoodTable;
-use crate::builder::cache::all_app::AllTable;
-use crate::builder::cache::ite::Ite;
-use crate::builder::cache::lru_app::BddApplyTable;
-use crate::repr::bdd::BddNode;
-use crate::repr::model::PartialModel;
-use crate::repr::var_order::VarOrder;
-
-use crate::backing_store::*;
-use crate::builder::BottomUpBuilder;
+use crate::{
+    backing_store::{BackedRobinhoodTable, UniqueTable},
+    builder::{
+        bdd::{BddBuilder, BddBuilderStats},
+        cache::{all_app::AllTable, ite::Ite, lru_app::BddApplyTable, LruTable},
+        BottomUpBuilder,
+    },
+    repr::{
+        bdd::{BddNode, BddPtr},
+        ddnnf::DDNNFPtr,
+        model::PartialModel,
+        var_label::VarLabel,
+        var_order::VarOrder,
+    },
+};
 use std::cell::RefCell;
-
-use crate::builder::cache::LruTable;
-use crate::repr::bdd::BddPtr;
-use crate::repr::ddnnf::DDNNFPtr;
-use crate::repr::var_label::VarLabel;
-
-use super::builder::BddBuilder;
-use super::stats::BddBuilderStats;
 
 pub struct RobddBuilder<'a, T: LruTable<'a, BddPtr<'a>>> {
     compute_table: RefCell<BackedRobinhoodTable<'a, BddNode<'a>>>,

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -1,10 +1,10 @@
 //! Apply cache for BDD operations that stores all ITEs
 
+use crate::{
+    builder::cache::{ite::Ite, LruTable},
+    repr::ddnnf::DDNNFPtr,
+};
 use rustc_hash::FxHashMap;
-
-use crate::repr::ddnnf::DDNNFPtr;
-
-use super::{ite::Ite, LruTable};
 
 /// An Ite structure, assumed to be in standard form.
 /// The top-level data structure that caches applications

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -1,9 +1,11 @@
 //! Apply cache for ITEs that uses a dynamically-expanding LRU cache
-use crate::{repr::ddnnf::DDNNFPtr, util::lru::*};
+use crate::{
+    builder::cache::{ite::Ite, LruTable},
+    repr::ddnnf::DDNNFPtr,
+    util::lru::*,
+};
 use rustc_hash::FxHasher;
 use std::hash::{Hash, Hasher};
-
-use super::{ite::Ite, LruTable};
 
 const INITIAL_CAPACITY: usize = 16; // given as a power of two
 

--- a/src/builder/decision_nnf/builder.rs
+++ b/src/builder/decision_nnf/builder.rs
@@ -7,12 +7,10 @@ use crate::{
         cnf::Cnf,
         ddnnf::DDNNFPtr,
         unit_prop::{DecisionResult, SATSolver},
-        var_label::Literal,
+        var_label::{Literal, VarLabel},
         var_order::VarOrder,
     },
 };
-
-use crate::repr::var_label::VarLabel;
 
 pub struct DecisionNNFBuilderStats {
     pub num_nodes_alloc: usize,

--- a/src/builder/decision_nnf/semantic.rs
+++ b/src/builder/decision_nnf/semantic.rs
@@ -1,11 +1,3 @@
-use std::{
-    cell::RefCell,
-    collections::HashSet,
-    hash::{Hash, Hasher},
-};
-
-use rustc_hash::FxHasher;
-
 use crate::{
     backing_store::BackedRobinhoodTable,
     builder::decision_nnf::builder::{DecisionNNFBuilder, DecisionNNFBuilderStats},
@@ -16,6 +8,12 @@ use crate::{
         wmc::WmcParams,
     },
     util::semirings::FiniteField,
+};
+use rustc_hash::FxHasher;
+use std::{
+    cell::RefCell,
+    collections::HashSet,
+    hash::{Hash, Hasher},
 };
 
 pub struct SemanticDecisionNNFBuilder<'a, const P: u128> {

--- a/src/builder/decision_nnf/standard.rs
+++ b/src/builder/decision_nnf/standard.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, collections::HashSet};
-
 use crate::{
-    backing_store::BackedRobinhoodTable,
+    backing_store::{BackedRobinhoodTable, UniqueTable},
     builder::decision_nnf::builder::{DecisionNNFBuilder, DecisionNNFBuilderStats},
     constants::primes,
     repr::{
@@ -10,8 +8,7 @@ use crate::{
         var_order::VarOrder,
     },
 };
-
-use crate::backing_store::UniqueTable;
+use std::{cell::RefCell, collections::HashSet};
 
 pub struct StandardDecisionNNFBuilder<'a> {
     compute_table: RefCell<BackedRobinhoodTable<'a, BddNode<'a>>>,

--- a/src/builder/sdd/builder.rs
+++ b/src/builder/sdd/builder.rs
@@ -1,16 +1,18 @@
 //! The main trait of the SDD manager, the primary way of interacting
 //! with SDDs.
 
+use crate::{
+    builder::{cache::ite::Ite, BottomUpBuilder},
+    repr::{
+        cnf::Cnf,
+        ddnnf::DDNNFPtr,
+        logical_expr::LogicalExpr,
+        sdd::{BinarySDD, SddAnd, SddOr, SddPtr},
+        var_label::VarLabel,
+        vtree::{VTree, VTreeIndex, VTreeManager},
+    },
+};
 use std::cmp::Ordering;
-
-use crate::builder::cache::ite::Ite;
-use crate::builder::BottomUpBuilder;
-use crate::repr::ddnnf::DDNNFPtr;
-use crate::repr::sdd::BinarySDD;
-use crate::repr::sdd::SddPtr::{self, Var};
-use crate::repr::sdd::{SddAnd, SddOr};
-use crate::repr::vtree::{VTree, VTreeIndex, VTreeManager};
-use crate::{repr::cnf::Cnf, repr::logical_expr::LogicalExpr, repr::var_label::VarLabel};
 
 #[derive(Default)]
 pub struct SddBuilderStats {
@@ -118,8 +120,8 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
         if self.get_vtree_manager().get_idx(lca).is_right_linear() {
             // a is a right-linear decision for b; construct a binary decision
             let bdd = match a {
-                Var(label, true) => BinarySDD::new(label, SddPtr::false_ptr(), b, lca),
-                Var(label, false) => BinarySDD::new(label, b, SddPtr::false_ptr(), lca),
+                SddPtr::Var(label, true) => BinarySDD::new(label, SddPtr::false_ptr(), b, lca),
+                SddPtr::Var(label, false) => BinarySDD::new(label, b, SddPtr::false_ptr(), lca),
                 _ => panic!(
                     "Assumed that a is a right-linear decision for b, but a is not a variable"
                 ),

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -1,19 +1,17 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-
-use crate::backing_store::BackedRobinhoodTable;
-use crate::backing_store::UniqueTable;
-use crate::builder::cache::all_app::AllTable;
-use crate::builder::cache::ite::Ite;
-use crate::builder::cache::LruTable;
-use crate::builder::BottomUpBuilder;
-use crate::repr::ddnnf::DDNNFPtr;
-use crate::repr::sdd::BinarySDD;
-use crate::repr::sdd::SddPtr;
-use crate::repr::sdd::{SddAnd, SddOr};
-use crate::repr::vtree::{VTree, VTreeIndex, VTreeManager};
-
-use super::builder::{SddBuilder, SddBuilderStats};
+use crate::{
+    backing_store::{BackedRobinhoodTable, UniqueTable},
+    builder::{
+        cache::{all_app::AllTable, ite::Ite, LruTable},
+        sdd::{SddBuilder, SddBuilderStats},
+        BottomUpBuilder,
+    },
+    repr::{
+        ddnnf::DDNNFPtr,
+        sdd::{BinarySDD, SddAnd, SddOr, SddPtr},
+        vtree::{VTree, VTreeIndex, VTreeManager},
+    },
+};
+use std::{cell::RefCell, collections::HashMap};
 
 pub struct CompressionSddBuilder<'a> {
     vtree: VTreeManager,

--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -1,20 +1,23 @@
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-
+use crate::{
+    backing_store::BackedRobinhoodTable,
+    builder::{
+        cache::ite::Ite,
+        sdd::{SddBuilder, SddBuilderStats},
+    },
+    repr::{
+        ddnnf::{create_semantic_hash_map, DDNNFPtr},
+        sdd::{BinarySDD, SddAnd, SddOr, SddPtr},
+        vtree::{VTree, VTreeIndex, VTreeManager},
+        wmc::WmcParams,
+    },
+    util::semirings::FiniteField,
+};
 use rustc_hash::FxHasher;
-
-use crate::backing_store::BackedRobinhoodTable;
-use crate::builder::cache::ite::Ite;
-use crate::repr::ddnnf::{create_semantic_hash_map, DDNNFPtr};
-use crate::repr::sdd::BinarySDD;
-use crate::repr::sdd::SddPtr;
-use crate::repr::sdd::{SddAnd, SddOr};
-use crate::repr::vtree::{VTree, VTreeIndex, VTreeManager};
-use crate::repr::wmc::WmcParams;
-use crate::util::semirings::FiniteField;
-
-use super::builder::{SddBuilder, SddBuilderStats};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    hash::{Hash, Hasher},
+};
 
 pub struct SemanticSddBuilder<'a, const P: u128> {
     vtree: VTreeManager,

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -1,21 +1,23 @@
 //! A representation of a conjunctive normal form (CNF)
 
-use crate::repr::var_label::{Literal, VarLabel};
-use crate::repr::var_order::VarOrder;
-use crate::util::semirings::Semiring;
-use petgraph::prelude::UnGraph;
-use rand;
-use rand::rngs::ThreadRng;
-use rand::Rng;
-use std::cmp::{max, min};
-use std::collections::HashSet;
-use std::fmt;
-extern crate quickcheck;
-use self::quickcheck::{Arbitrary, Gen};
-use crate::repr::model::PartialModel;
+use crate::{
+    repr::{
+        model::PartialModel,
+        var_label::{Literal, VarLabel},
+        var_order::VarOrder,
+        wmc::WmcParams,
+    },
+    util::semirings::Semiring,
+};
 use petgraph::graph::NodeIndex;
-
-use super::wmc::WmcParams;
+use petgraph::prelude::UnGraph;
+use quickcheck::{Arbitrary, Gen};
+use rand::{self, rngs::ThreadRng, Rng};
+use std::{
+    cmp::{max, min},
+    collections::HashSet,
+    fmt,
+};
 
 // number of primes to consider during CNF hashing
 const NUM_PRIMES: usize = 2;

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -1,11 +1,15 @@
 //! Implementing of a generic decision decomposable deterministic negation normal form
 //! (d-DNNF) pointer type
-use core::fmt::Debug;
-
-use crate::util::semirings::Semiring;
-use crate::util::semirings::{BooleanSemiring, FiniteField};
+use crate::{
+    repr::{
+        var_label::{VarLabel, VarSet},
+        wmc::WmcParams,
+    },
+    util::semirings::{BooleanSemiring, FiniteField, Semiring},
+};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
+use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
 /// creates a weighting that can be used for semantically hashing a DDNNF node
 /// the constant `P` denotes the size of the field over which the semantic hash will
@@ -40,11 +44,6 @@ pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<Fin
     WmcParams::new(map)
 }
 
-use super::{
-    var_label::{VarLabel, VarSet},
-    wmc::WmcParams,
-};
-use std::{collections::HashMap, hash::Hash};
 /// A base d-DNNF type
 pub enum DDNNF<T> {
     /// contains the cached values for the children, and the VarSet that

--- a/src/repr/dtree.rs
+++ b/src/repr/dtree.rs
@@ -42,10 +42,8 @@
 //! The *cut-width* of a dtree is the size of the largest cutset. An effective
 //! dtree is one that does not have large cutwidth.
 
-use crate::repr::{cnf::Cnf, var_label::Literal};
+use crate::repr::{cnf::Cnf, var_label::Literal, var_label::VarSet, var_order::VarOrder};
 use serde::Serialize;
-
-use super::{var_label::VarSet, var_order::VarOrder};
 
 #[derive(Clone, Debug, Serialize)]
 pub enum DTree {

--- a/src/repr/logical_expr.rs
+++ b/src/repr/logical_expr.rs
@@ -2,9 +2,7 @@
 
 use crate::repr::var_label::VarLabel;
 use dimacs::*;
-use rand;
-use rand::rngs::ThreadRng;
-use rand::Rng;
+use rand::{self, rngs::ThreadRng, Rng};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/repr/model.rs
+++ b/src/repr/model.rs
@@ -1,8 +1,7 @@
 //! Models and partial models of logical sentences
 
+use crate::repr::var_label::{Literal, VarLabel, VarSet};
 use std::fmt::Display;
-
-use super::var_label::{Literal, VarLabel, VarSet};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PartialModel {

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -13,12 +13,8 @@ use crate::{
     },
     util::semirings::FiniteField,
 };
-
-use std::fmt::Debug;
-use std::{collections::HashSet, ptr};
+use std::{collections::HashSet, fmt::Debug, hash::Hash, ptr};
 use SddPtr::*;
-
-use std::hash::Hash;
 
 pub use self::binary_sdd::*;
 pub use self::sdd_or::*;

--- a/src/repr/sdd/binary_sdd.rs
+++ b/src/repr/sdd/binary_sdd.rs
@@ -1,19 +1,17 @@
-use std::{
-    any::Any,
-    cell::RefCell,
-    hash::{Hash, Hasher},
-};
-
 use crate::{
     repr::{
+        sdd::SddPtr,
         var_label::VarLabel,
         vtree::{VTreeIndex, VTreeManager},
         wmc::WmcParams,
     },
     util::semirings::FiniteField,
 };
-
-use super::SddPtr;
+use std::{
+    any::Any,
+    cell::RefCell,
+    hash::{Hash, Hasher},
+};
 
 /// Specialized SDD node for a right-linear sub-vtree
 /// SDDs for these fragments are binary decisions

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -1,18 +1,16 @@
-use std::{
-    any::Any,
-    cell::RefCell,
-    hash::{Hash, Hasher},
-};
-
 use crate::{
     repr::{
+        sdd::SddPtr::{self, Compl, ComplBDD, PtrFalse, PtrTrue, Reg, Var, BDD},
         vtree::{VTreeIndex, VTreeManager},
         wmc::WmcParams,
     },
     util::semirings::FiniteField,
 };
-
-use super::SddPtr::{self, Compl, ComplBDD, PtrFalse, PtrTrue, Reg, Var, BDD};
+use std::{
+    any::Any,
+    cell::RefCell,
+    hash::{Hash, Hasher},
+};
 
 /// An SddOr node is a vector of (prime, sub) pairs.
 #[derive(Debug)]

--- a/src/repr/unit_prop.rs
+++ b/src/repr/unit_prop.rs
@@ -22,7 +22,7 @@
 //! Then, if we were to hash this CNF with the partial model (a = T), would
 //! get the value 7
 
-use super::{
+use crate::repr::{
     cnf::Cnf,
     model::PartialModel,
     var_label::{Literal, VarLabel},

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -1,11 +1,8 @@
 //! A generic data structure for tracking variable labels throughout the library
+use bit_set::BitSet;
+use quickcheck::{Arbitrary, Gen};
 use serde::Serialize;
 use std::fmt::{self, Display};
-
-extern crate quickcheck;
-use bit_set::BitSet;
-
-use self::quickcheck::{Arbitrary, Gen};
 
 /// a label for each distinct variable in the BDD
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, Copy, PartialOrd, Ord)]

--- a/src/repr/var_order.rs
+++ b/src/repr/var_order.rs
@@ -2,12 +2,11 @@
 //! in the order occur first in the BDD, starting from the root.
 //! Lower numbers occur first in the order (i.e., closer to the root)
 
-use crate::repr::var_label::VarLabel;
-use crate::util;
-use std::fmt::Display;
-use std::slice::Iter;
-
-use super::bdd::BddPtr;
+use crate::{
+    repr::{bdd::BddPtr, var_label::VarLabel},
+    util,
+};
+use std::{fmt::Display, slice::Iter};
 
 #[derive(Debug, Clone)]
 pub struct VarOrder {

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -1,16 +1,17 @@
 //! Defines the vtree datastructure used by SDDs for decomposition
 
-use std::collections::HashSet;
-
-use super::var_label::VarSet;
-use super::{sdd::SddPtr, var_label::VarLabel};
-use crate::quickcheck::{Arbitrary, Gen};
-use crate::repr::dtree::DTree;
-use crate::util::btree::{BTree, LeastCommonAncestor};
-use rand::rngs::SmallRng;
-use rand::seq::SliceRandom;
-use rand::{Rng, SeedableRng};
+use crate::{
+    repr::{
+        dtree::DTree,
+        sdd::SddPtr,
+        var_label::{VarLabel, VarSet},
+    },
+    util::btree::{BTree, LeastCommonAncestor},
+};
+use quickcheck::{Arbitrary, Gen};
+use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
+use std::collections::HashSet;
 
 pub type VTree = BTree<(), VarLabel>;
 

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -1,10 +1,9 @@
+use crate::{
+    repr::var_label::{Literal, VarLabel},
+    util::semirings::Semiring,
+};
 use core::fmt::Debug;
 use std::collections::HashMap;
-
-use crate::util::semirings::Semiring;
-
-use super::var_label::{Literal, VarLabel};
-
 /// Weighted model counting parameters for a BDD. It primarily is a storage for
 /// the weight on each variable.
 #[derive(Clone)]

--- a/src/util/hypergraph.rs
+++ b/src/util/hypergraph.rs
@@ -1,8 +1,5 @@
-use crate::repr::cnf::Cnf;
-use crate::repr::var_label::VarLabel;
-use core::fmt::Debug;
-use core::hash::Hash;
-
+use crate::repr::{cnf::Cnf, var_label::VarLabel};
+use core::{fmt::Debug, hash::Hash};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, Debug)]

--- a/src/util/lru.rs
+++ b/src/util/lru.rs
@@ -1,8 +1,7 @@
 //! A generic lossy LRU cache
 //! will automatically grow in size if it hits a certain size threshold
 
-use std::fmt::Debug;
-use std::hash::Hash;
+use std::{fmt::Debug, hash::Hash};
 
 // if the LRU is GROW_RATIO% full, it will double in size on insertion
 const GROW_RATIO: f64 = 0.7;

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,17 +1,17 @@
-use crate::builder::bdd::BddBuilder;
-use crate::builder::bdd::RobddBuilder;
-use crate::builder::cache::lru_app::BddApplyTable;
-use crate::builder::sdd::CompressionSddBuilder;
-use crate::builder::sdd::SddBuilder;
-use crate::constants::primes;
-use crate::repr::bdd::BddPtr;
-use crate::repr::ddnnf::DDNNFPtr;
-use crate::repr::dtree::DTree;
-use crate::repr::var_order::VarOrder;
-use crate::repr::wmc::WmcParams;
-use crate::repr::{cnf::Cnf, var_label::VarLabel, vtree::VTree};
-use crate::serialize::{BDDSerializer, SDDSerializer, VTreeSerializer};
-use crate::util::semirings::FiniteField;
+use crate::{
+    builder::{
+        bdd::{BddBuilder, RobddBuilder},
+        cache::lru_app::BddApplyTable,
+        sdd::{CompressionSddBuilder, SddBuilder},
+    },
+    constants::primes,
+    repr::{
+        bdd::BddPtr, cnf::Cnf, ddnnf::DDNNFPtr, dtree::DTree, var_label::VarLabel,
+        var_order::VarOrder, vtree::VTree, wmc::WmcParams,
+    },
+    serialize::{BDDSerializer, SDDSerializer, VTreeSerializer},
+    util::semirings::FiniteField,
+};
 use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Deserialize)]
@@ -49,7 +49,8 @@ pub fn vtree(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, Js
 pub fn bdd(cnf_input: String) -> String {
     let cnf = Cnf::from_file(cnf_input);
 
-    let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
+    let builder: RobddBuilder<'_, BddApplyTable<BddPtr<'_>>> =
+        RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
     let bdd = builder.compile_cnf(&cnf);
 
     let json = BDDSerializer::from_bdd(bdd);


### PR DESCRIPTION
Why isn't this automatable :(

- all imports stem from `crate::`
- proper sorting
- no use of `super::` when possible
- no more duplicate `extern`