### PR TITLE
Parameter consistency on `&str`, doctests

### DIFF
--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -57,7 +57,7 @@ fn main() {
 
     let cnf_input = fs::read_to_string(args.file).expect("Should have been able to read the file");
 
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
     println!("num vars: {}", cnf.num_vars());
 
     // TODO: allow user to pick varorder

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -79,7 +79,7 @@ struct BenchResult {
 }
 
 fn compile_topdown_nnf(str: String, _args: &Args) -> BenchResult {
-    let cnf = Cnf::from_file(str);
+    let cnf = Cnf::from_dimacs(&str);
     let order = VarOrder::linear_order(cnf.num_vars());
     let builder = StandardDecisionNNFBuilder::new(order);
     // let order = cnf.force_order();
@@ -92,7 +92,7 @@ fn compile_topdown_nnf(str: String, _args: &Args) -> BenchResult {
 }
 
 fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
-    let cnf = Cnf::from_file(str);
+    let cnf = Cnf::from_dimacs(&str);
     let dtree = DTree::from_cnf(&cnf, &cnf.min_fill_order());
     let vtree = VTree::from_dtree(&dtree).unwrap();
     let builder = CompressionSddBuilder::new(vtree.clone());
@@ -119,7 +119,7 @@ fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
 }
 
 fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
-    let cnf = Cnf::from_file(str);
+    let cnf = Cnf::from_dimacs(&str);
     let o: Vec<VarLabel> = (0..cnf.num_vars())
         .map(|x| VarLabel::new(x as u64))
         .collect();
@@ -148,7 +148,7 @@ fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
 }
 
 fn compile_bdd(str: String, _args: &Args) -> BenchResult {
-    let cnf = Cnf::from_file(str);
+    let cnf = Cnf::from_dimacs(&str);
     let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
     let bdd = builder.compile_cnf(&cnf);
 
@@ -166,7 +166,7 @@ fn compile_bdd(str: String, _args: &Args) -> BenchResult {
 }
 
 fn compile_bdd_dtree(str: String, _args: &Args) -> BenchResult {
-    let cnf = Cnf::from_file(str);
+    let cnf = Cnf::from_dimacs(&str);
     let order = cnf.min_fill_order();
     let dtree = DTree::from_cnf(&cnf, &order);
     let builder =

--- a/examples/semantic_hash_experiment.rs
+++ b/examples/semantic_hash_experiment.rs
@@ -213,7 +213,7 @@ fn main() {
 
     let cnf_input = fs::read_to_string(args.file).expect("Should have been able to read the file");
 
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
     let range: Vec<usize> = (0..cnf.num_vars()).collect();
     let binding = range
         .iter()

--- a/examples/semantic_top_down_experiment.rs
+++ b/examples/semantic_top_down_experiment.rs
@@ -134,7 +134,7 @@ fn main() {
 
     let cnf_input = fs::read_to_string(args.file).expect("Should have been able to read the file");
 
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
 
     let mut avg_sem_nodes = 0;
     let mut avg_std_nodes = 0;

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -613,8 +613,8 @@ mod tests {
     #[test]
     fn test_ite_1() {
         let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(16);
-        let c1 = Cnf::from_string(String::from("(1 || 2) && (0 || -2)"));
-        let c2 = Cnf::from_string(String::from("(0 || 1) && (-4 || -7)"));
+        let c1 = Cnf::from_string("(1 || 2) && (0 || -2)");
+        let c2 = Cnf::from_string("(0 || 1) && (-4 || -7)");
         let cnf1 = builder.compile_cnf(&c1);
         let cnf2 = builder.compile_cnf(&c2);
         let iff1 = builder.iff(cnf1, cnf2);
@@ -641,7 +641,7 @@ mod tests {
         p cnf 3 1
         1 2 3 0
         ";
-        let cnf = Cnf::from_file(String::from(CNF));
+        let cnf = Cnf::from_dimacs(CNF);
 
         let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
 
@@ -672,7 +672,7 @@ mod tests {
         -1 2 0
         1 -2 0
         ";
-        let cnf = Cnf::from_file(String::from(CNF));
+        let cnf = Cnf::from_dimacs(CNF);
 
         let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
 
@@ -700,7 +700,7 @@ mod tests {
         -2 -3 4 5 0
         -4 -5 6 6 0
         ";
-        let cnf = Cnf::from_file(String::from(CNF));
+        let cnf = Cnf::from_dimacs(CNF);
 
         let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
 

--- a/src/builder/decision_nnf/semantic.rs
+++ b/src/builder/decision_nnf/semantic.rs
@@ -125,7 +125,7 @@ mod tests {
         1 2 0
         ";
 
-        let cnf = Cnf::from_file(String::from(CNF));
+        let cnf = Cnf::from_dimacs(CNF);
 
         let linear_order = VarOrder::linear_order(cnf.num_vars());
 

--- a/src/builder/decision_nnf/standard.rs
+++ b/src/builder/decision_nnf/standard.rs
@@ -82,7 +82,7 @@ mod tests {
         1 2 0
         ";
 
-        let cnf = Cnf::from_file(String::from(CNF));
+        let cnf = Cnf::from_dimacs(CNF);
 
         let linear_order = VarOrder::linear_order(cnf.num_vars());
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,20 @@
+/// primes that are used by elements of rsdd,
+/// primarily in integer-approximating finite fields
 pub mod primes {
+    /// ```
+    /// use rsdd::constants::primes;
+    /// assert!(primes::U32_TINY < u32::MAX as u128);
+    /// ```
     pub const U32_TINY: u128 = 1000001;
+    /// ```
+    /// use rsdd::constants::primes;
+    /// assert!(primes::U32_SMALL < u32::MAX as u128);
+    /// ```
     pub const U32_SMALL: u128 = 479001599;
+    /// ```
+    /// use rsdd::constants::primes;
+    /// assert!(primes::U64_LARGEST < u64::MAX as u128);
+    /// ```
     pub const U64_LARGEST: u128 = 18_446_744_073_709_551_591;
     pub const U128_LARGE_1: u128 = 46084029846212370199652019757;
     pub const U128_LARGE_2: u128 = 49703069216273825773136967137;

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -294,9 +294,9 @@ impl Cnf {
         }
     }
 
-    pub fn from_file(input: String) -> Cnf {
+    pub fn from_dimacs(input: &str) -> Cnf {
         use dimacs::*;
-        let (_, cvec) = match parse_dimacs(&input).unwrap() {
+        let (_, cvec) = match parse_dimacs(input).unwrap() {
             Instance::Cnf { num_vars, clauses } => (num_vars, clauses),
             Instance::Sat {
                 num_vars: _,
@@ -329,7 +329,7 @@ impl Cnf {
     /// - Each clause in its own parenthesis and separated by &&
     /// - Each literal separated by ||
     /// - Literal negation implied by "-"
-    pub fn from_string(s: String) -> Cnf {
+    pub fn from_string(s: &str) -> Cnf {
         let clauses = s.split("&&");
         let mut clause_vec: Vec<Vec<Literal>> = Vec::new();
         for clause in clauses {

--- a/src/repr/dtree.rs
+++ b/src/repr/dtree.rs
@@ -227,7 +227,7 @@ impl DTree {
 
 #[test]
 fn test_dtree() {
-    let cnf = Cnf::from_string(String::from("(1 || -2) && (2 || 3) && (3 || 4) "));
+    let cnf = Cnf::from_string("(1 || -2) && (2 || 3) && (3 || 4) ");
     // let cnf = Cnf::from_string(String::from("(1 || -2 || 3) && (2 || 3)"));
     // let cnf = Cnf::from_string(String::from("(3 || 4) && (1 || 2) "));
     println!("cnf: {:?}", cnf.to_string());

--- a/src/repr/logical_expr.rs
+++ b/src/repr/logical_expr.rs
@@ -29,8 +29,19 @@ impl LogicalExpr {
     /// -54 37 0
     /// ...
     /// Where negative indicates a false variable, 0 is line end
-    pub fn from_dimacs(input: String) -> LogicalExpr {
-        let (_, cvec) = match parse_dimacs(&input).unwrap() {
+    /// ```
+    /// use rsdd::repr::logical_expr::LogicalExpr;
+    ///
+    /// static CNF: &str = r#"
+    /// p cnf 3 1
+    /// 1 -2 3 0
+    /// "#;
+    ///
+    /// let expr = LogicalExpr::from_dimacs(CNF);
+    /// assert!(matches!(expr, LogicalExpr::Or(_, _)));
+    /// ```
+    pub fn from_dimacs(input: &str) -> LogicalExpr {
+        let (_, cvec) = match parse_dimacs(input).unwrap() {
             Instance::Cnf { num_vars, clauses } => (num_vars, clauses),
             Instance::Sat {
                 num_vars: _,
@@ -109,7 +120,35 @@ impl LogicalExpr {
             })
     }
 
-    /// Evaluates a boolean expression
+    /// Evaluates a boolean expression.
+    /// ```
+    /// use rsdd::repr::logical_expr::LogicalExpr;
+    /// use rsdd::repr::var_label::VarLabel;
+    /// use std::collections::HashMap;
+    ///
+    /// static CNF: &str = r#"
+    /// p cnf 3 1
+    /// 1 -2 3 0
+    /// "#;
+    ///
+    /// let expr = LogicalExpr::from_dimacs(CNF);
+    ///
+    /// assert!(expr.eval(
+    ///     &HashMap::from([
+    ///         (VarLabel::new(1), true),
+    ///         (VarLabel::new(2), true),
+    ///         (VarLabel::new(3), true)
+    ///     ])
+    /// ));
+    ///
+    /// assert!(!expr.eval(
+    ///     &HashMap::from([
+    ///         (VarLabel::new(1), false),
+    ///         (VarLabel::new(2), true),
+    ///         (VarLabel::new(3), false)
+    ///     ])
+    /// ));
+    /// ```
     pub fn eval(&self, values: &HashMap<VarLabel, bool>) -> bool {
         match &self {
             LogicalExpr::Literal(lbl, polarity) => {

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -401,9 +401,8 @@ fn from_dtree_is_valid_vtree() {
     let cnf_input = "p cnf 3 6
     1 2 3 4 0
     -2 -3 4 5 0
-    -4 -5 6 6 0"
-        .to_string();
-    let cnf = super::cnf::Cnf::from_file(cnf_input);
+    -4 -5 6 6 0";
+    let cnf = super::cnf::Cnf::from_dimacs(cnf_input);
     let dtree = DTree::from_cnf(&cnf, &cnf.min_fill_order());
     let vtree = VTree::from_dtree(&dtree).unwrap();
     println!("{:?}", VTree::flatten_vtree(&vtree));

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -33,7 +33,7 @@ pub struct SddModelCountResult {
 // used in: https://github.com/mattxwang/indecision
 #[wasm_bindgen]
 pub fn vtree(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, JsValue> {
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
 
     let vtree_type: VTreeType = serde_wasm_bindgen::from_value(vtree_type_input)?;
 
@@ -47,7 +47,7 @@ pub fn vtree(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, Js
 // used in: https://github.com/mattxwang/indecision
 #[wasm_bindgen]
 pub fn bdd(cnf_input: String) -> String {
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
 
     let builder: RobddBuilder<'_, BddApplyTable<BddPtr<'_>>> =
         RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
@@ -61,7 +61,7 @@ pub fn bdd(cnf_input: String) -> String {
 // used in: https://github.com/mattxwang/indecision
 #[wasm_bindgen]
 pub fn bdd_with_var_order(cnf_input: String, order: &[u64]) -> String {
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
 
     let var_order = VarOrder::new(order.iter().map(|v| VarLabel::new(*v)).collect());
 
@@ -76,7 +76,7 @@ pub fn bdd_with_var_order(cnf_input: String, order: &[u64]) -> String {
 // used in: https://github.com/mattxwang/indecision
 #[wasm_bindgen]
 pub fn sdd(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, JsValue> {
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
 
     let vtree_type: VTreeType = serde_wasm_bindgen::from_value(vtree_type_input)?;
 
@@ -93,7 +93,7 @@ pub fn sdd(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, JsVa
 // used in rsdd-docs
 #[wasm_bindgen]
 pub fn demo_model_count_sdd(cnf_input: String) -> Result<JsValue, JsValue> {
-    let cnf = Cnf::from_file(cnf_input);
+    let cnf = Cnf::from_dimacs(&cnf_input);
 
     let vtree = build_vtree(&cnf, VTreeType::FromDTreeLinear);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -187,62 +187,20 @@ p cnf 2 1
 
 fn get_canonical_forms() -> Vec<(Cnf, Cnf)> {
     vec![
-        (
-            Cnf::from_file(String::from(C1_A)),
-            Cnf::from_file(String::from(C1_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C2_A)),
-            Cnf::from_file(String::from(C2_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C3_A)),
-            Cnf::from_file(String::from(C3_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C4_A)),
-            Cnf::from_file(String::from(C4_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C5_A)),
-            Cnf::from_file(String::from(C5_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C6_A)),
-            Cnf::from_file(String::from(C6_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C7_A)),
-            Cnf::from_file(String::from(C7_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C8_A)),
-            Cnf::from_file(String::from(C8_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C9_A)),
-            Cnf::from_file(String::from(C9_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C10_A)),
-            Cnf::from_file(String::from(C10_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C11_A)),
-            Cnf::from_file(String::from(C11_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C12_A)),
-            Cnf::from_file(String::from(C12_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C13_A)),
-            Cnf::from_file(String::from(C13_B)),
-        ),
-        (
-            Cnf::from_file(String::from(C14_A)),
-            Cnf::from_file(String::from(C14_B)),
-        ),
+        (Cnf::from_dimacs(C1_A), Cnf::from_dimacs(C1_B)),
+        (Cnf::from_dimacs(C2_A), Cnf::from_dimacs(C2_B)),
+        (Cnf::from_dimacs(C3_A), Cnf::from_dimacs(C3_B)),
+        (Cnf::from_dimacs(C4_A), Cnf::from_dimacs(C4_B)),
+        (Cnf::from_dimacs(C5_A), Cnf::from_dimacs(C5_B)),
+        (Cnf::from_dimacs(C6_A), Cnf::from_dimacs(C6_B)),
+        (Cnf::from_dimacs(C7_A), Cnf::from_dimacs(C7_B)),
+        (Cnf::from_dimacs(C8_A), Cnf::from_dimacs(C8_B)),
+        (Cnf::from_dimacs(C9_A), Cnf::from_dimacs(C9_B)),
+        (Cnf::from_dimacs(C10_A), Cnf::from_dimacs(C10_B)),
+        (Cnf::from_dimacs(C11_A), Cnf::from_dimacs(C11_B)),
+        (Cnf::from_dimacs(C12_A), Cnf::from_dimacs(C12_B)),
+        (Cnf::from_dimacs(C13_A), Cnf::from_dimacs(C13_B)),
+        (Cnf::from_dimacs(C14_A), Cnf::from_dimacs(C14_B)),
     ]
 }
 


### PR DESCRIPTION
We never really need ownership of the underlying `String` in the `from_` cases. Also, `from_file` is misleading, since it's not actually from a file.