### PR TITLE
Align with rust naming conventions

### DIFF
--- a/src/builder/bdd/builder.rs
+++ b/src/builder/bdd/builder.rs
@@ -51,12 +51,12 @@ pub trait BddBuilder<'a>: BottomUpBuilder<'a, BddPtr<'a>> {
         for clause in clauses.iter() {
             let mut cur_ptr = BddPtr::false_ptr();
             for lit in clause.iter() {
-                match assgn.get(lit.get_label()) {
+                match assgn.get(lit.label()) {
                     None => {
-                        let new_v = self.var(lit.get_label(), lit.get_polarity());
+                        let new_v = self.var(lit.label(), lit.polarity());
                         cur_ptr = self.or(new_v, cur_ptr);
                     }
-                    Some(v) if v == lit.get_polarity() => {
+                    Some(v) if v == lit.polarity() => {
                         cur_ptr = BddPtr::true_ptr();
                         break;
                     }
@@ -99,7 +99,7 @@ pub trait BddBuilder<'a>: BottomUpBuilder<'a, BddPtr<'a>> {
             let fst1 = c1
                 .iter()
                 .max_by(|l1, l2| {
-                    if self.less_than(l1.get_label(), l2.get_label()) {
+                    if self.less_than(l1.label(), l2.label()) {
                         Ordering::Less
                     } else {
                         Ordering::Equal
@@ -109,14 +109,14 @@ pub trait BddBuilder<'a>: BottomUpBuilder<'a, BddPtr<'a>> {
             let fst2 = c2
                 .iter()
                 .max_by(|l1, l2| {
-                    if self.less_than(l1.get_label(), l2.get_label()) {
+                    if self.less_than(l1.label(), l2.label()) {
                         Ordering::Less
                     } else {
                         Ordering::Equal
                     }
                 })
                 .unwrap();
-            if self.less_than(fst1.get_label(), fst2.get_label()) {
+            if self.less_than(fst1.label(), fst2.label()) {
                 Ordering::Less
             } else {
                 Ordering::Equal
@@ -124,10 +124,10 @@ pub trait BddBuilder<'a>: BottomUpBuilder<'a, BddPtr<'a>> {
         });
 
         for lit_vec in cnf_sorted.iter() {
-            let (vlabel, val) = (lit_vec[0].get_label(), lit_vec[0].get_polarity());
+            let (vlabel, val) = (lit_vec[0].label(), lit_vec[0].polarity());
             let mut bdd = self.var(vlabel, val);
             for lit in lit_vec {
-                let (vlabel, val) = (lit.get_label(), lit.get_polarity());
+                let (vlabel, val) = (lit.label(), lit.polarity());
                 let var = self.var(vlabel, val);
                 bdd = self.or(bdd, var);
             }

--- a/src/builder/bdd/mod.rs
+++ b/src/builder/bdd/mod.rs
@@ -1,4 +1,4 @@
-use crate::repr::{bdd::BddPtr, var_label::VarLabel};
+use crate::repr::bdd::BddPtr;
 use std::cmp::Ordering;
 
 mod builder;
@@ -33,20 +33,5 @@ impl<'a> Ord for CompiledCNF<'a> {
 impl<'a> PartialOrd for CompiledCNF<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-#[derive(Debug)]
-pub struct Assignment {
-    assignments: Vec<bool>,
-}
-
-impl Assignment {
-    pub fn new(assignments: Vec<bool>) -> Assignment {
-        Assignment { assignments }
-    }
-
-    pub fn get_assignment(&self, var: VarLabel) -> bool {
-        self.assignments[var.value() as usize]
     }
 }

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -252,7 +252,7 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
         // TODO: optimize this
         let mut bdd = bdd;
         for m in m.assignment_iter() {
-            bdd = self.condition(bdd, m.get_label(), m.get_polarity());
+            bdd = self.condition(bdd, m.label(), m.polarity());
         }
         bdd
     }

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -153,7 +153,7 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
 
     /// Get the current variable order
     #[inline]
-    pub fn get_order(&self) -> &VarOrder {
+    pub fn order(&self) -> &VarOrder {
         // TODO fix this, it doesn't need to be unsafe
         unsafe { &*self.order.as_ptr() }
     }
@@ -387,7 +387,7 @@ mod tests {
             (VarLabel::new(1), (RealSemiring(0.1), RealSemiring(0.9))),
         ]);
         let params = WmcParams::new(weights);
-        let wmc = r1.wmc(builder.get_order().borrow(), &params);
+        let wmc = r1.wmc(builder.order().borrow(), &params);
         assert!((wmc.0 - (1.0 - 0.2 * 0.1)).abs() < 0.000001);
     }
 
@@ -605,7 +605,7 @@ mod tests {
         let and1 = builder.and(iff1, iff2);
         let f = builder.and(and1, obs);
         assert_eq!(
-            f.wmc(builder.get_order().borrow(), &wmc).0,
+            f.wmc(builder.order().borrow(), &wmc).0,
             0.2 * 0.3 + 0.2 * 0.7 + 0.8 * 0.3
         );
     }
@@ -655,9 +655,9 @@ mod tests {
             (VarLabel::new(2), (FiniteField::new(1), FiniteField::new(1))),
         ]));
 
-        let unsmoothed_model_count = bdd.wmc(builder.get_order(), &weights);
+        let unsmoothed_model_count = bdd.wmc(builder.order(), &weights);
 
-        let smoothed_model_count = smoothed.wmc(builder.get_order(), &weights);
+        let smoothed_model_count = smoothed.wmc(builder.order(), &weights);
 
         assert_eq!(unsmoothed_model_count.value(), 3);
         assert_eq!(smoothed_model_count.value(), 7);
@@ -681,7 +681,7 @@ mod tests {
         let smoothed = builder.smooth(bdd, cnf.num_vars());
 
         let weighted_model_count = smoothed.wmc(
-            builder.get_order(),
+            builder.order(),
             &WmcParams::<RealSemiring>::new(HashMap::from_iter([
                 (VarLabel::new(0), (RealSemiring(0.4), RealSemiring(0.6))),
                 (VarLabel::new(1), (RealSemiring(0.3), RealSemiring(0.7))),
@@ -709,7 +709,7 @@ mod tests {
         let smoothed = builder.smooth(bdd, cnf.num_vars());
 
         let model_count = smoothed.wmc(
-            builder.get_order(),
+            builder.order(),
             &WmcParams::<FiniteField<1000001>>::new(HashMap::from_iter([
                 (VarLabel::new(0), (FiniteField::new(1), FiniteField::new(1))),
                 (VarLabel::new(1), (FiniteField::new(1), FiniteField::new(1))),
@@ -722,7 +722,7 @@ mod tests {
 
         // TODO: this WMC test is broken. not sure why :(
         // let weighted_model_count = smoothed.wmc(
-        //     builder.get_order(),
+        //     builder.order(),
         //     &WmcParams::new(HashMap::from_iter([
         //         // (VarLabel::new(0), (RealSemiring(0.10), RealSemiring(0.05))),
         //         // (VarLabel::new(1), (RealSemiring(0.20), RealSemiring(0.15))),

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -198,7 +198,7 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
                 }
 
                 // check cache
-                match bdd.get_scratch::<usize>() {
+                match bdd.scratch::<usize>() {
                     None => (),
                     Some(v) => {
                         return if bdd.is_neg() {

--- a/src/builder/decision_nnf/builder.rs
+++ b/src/builder/decision_nnf/builder.rs
@@ -159,7 +159,7 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
             }
             BddPtr::Reg(node) | BddPtr::Compl(node) => {
                 // check cache
-                if let Some(v) = bdd.get_scratch::<BddPtr>() {
+                if let Some(v) = bdd.scratch::<BddPtr>() {
                     return if bdd.is_neg() { v.neg() } else { v };
                 }
 

--- a/src/builder/decision_nnf/builder.rs
+++ b/src/builder/decision_nnf/builder.rs
@@ -85,14 +85,14 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         let high_bdd = match sat.decide(Literal::new(cur_v, true)) {
             DecisionResult::UNSAT => BddPtr::false_ptr(),
             DecisionResult::SAT => {
-                let new_assgn = sat.get_difference().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, BddPtr::true_ptr());
                 sat.pop();
                 r
             }
             DecisionResult::Unknown => {
                 let sub = self.topdown_h(cnf, sat, level + 1, cache);
-                let new_assgn = sat.get_difference().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, sub);
                 sat.pop();
                 r
@@ -101,14 +101,14 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         let low_bdd = match sat.decide(Literal::new(cur_v, false)) {
             DecisionResult::UNSAT => BddPtr::false_ptr(),
             DecisionResult::SAT => {
-                let new_assgn = sat.get_difference().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, BddPtr::true_ptr());
                 sat.pop();
                 r
             }
             DecisionResult::Unknown => {
                 let sub = self.topdown_h(cnf, sat, level + 1, cache);
-                let new_assgn = sat.get_difference().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, sub);
                 sat.pop();
                 r
@@ -135,7 +135,7 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         let mut r = self.topdown_h(cnf, &mut sat, 0, &mut FxHashMap::default());
 
         // conjoin in any initially implied literals
-        for l in sat.get_difference() {
+        for l in sat.difference_iter() {
             let node = if l.get_polarity() {
                 BddNode::new(l.get_label(), BddPtr::false_ptr(), r)
             } else {

--- a/src/builder/decision_nnf/builder.rs
+++ b/src/builder/decision_nnf/builder.rs
@@ -39,10 +39,10 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         }
         let mut sub = nnf;
         for l in literals {
-            let node = if l.get_polarity() {
-                BddNode::new(l.get_label(), BddPtr::false_ptr(), sub)
+            let node = if l.polarity() {
+                BddNode::new(l.label(), BddPtr::false_ptr(), sub)
             } else {
-                BddNode::new(l.get_label(), sub, BddPtr::false_ptr())
+                BddNode::new(l.label(), sub, BddPtr::false_ptr())
             };
             sub = self.get_or_insert(node);
         }
@@ -73,7 +73,7 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         }
 
         // check cache
-        let hashed = sat.get_cur_hash();
+        let hashed = sat.cur_hash();
         match cache.get(&hashed) {
             None => (),
             Some(v) => {
@@ -85,14 +85,14 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         let high_bdd = match sat.decide(Literal::new(cur_v, true)) {
             DecisionResult::UNSAT => BddPtr::false_ptr(),
             DecisionResult::SAT => {
-                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, BddPtr::true_ptr());
                 sat.pop();
                 r
             }
             DecisionResult::Unknown => {
                 let sub = self.topdown_h(cnf, sat, level + 1, cache);
-                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, sub);
                 sat.pop();
                 r
@@ -101,14 +101,14 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
         let low_bdd = match sat.decide(Literal::new(cur_v, false)) {
             DecisionResult::UNSAT => BddPtr::false_ptr(),
             DecisionResult::SAT => {
-                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, BddPtr::true_ptr());
                 sat.pop();
                 r
             }
             DecisionResult::Unknown => {
                 let sub = self.topdown_h(cnf, sat, level + 1, cache);
-                let new_assgn = sat.difference_iter().filter(|x| x.get_label() != cur_v);
+                let new_assgn = sat.difference_iter().filter(|x| x.label() != cur_v);
                 let r = self.conjoin_implied(new_assgn, sub);
                 sat.pop();
                 r
@@ -136,10 +136,10 @@ pub trait DecisionNNFBuilder<'a>: TopDownBuilder<'a, BddPtr<'a>> {
 
         // conjoin in any initially implied literals
         for l in sat.difference_iter() {
-            let node = if l.get_polarity() {
-                BddNode::new(l.get_label(), BddPtr::false_ptr(), r)
+            let node = if l.polarity() {
+                BddNode::new(l.label(), BddPtr::false_ptr(), r)
             } else {
-                BddNode::new(l.get_label(), r, BddPtr::false_ptr())
+                BddNode::new(l.label(), r, BddPtr::false_ptr())
             };
             r = self.get_or_insert(node);
         }

--- a/src/builder/sdd/builder.rs
+++ b/src/builder/sdd/builder.rs
@@ -27,7 +27,7 @@ pub struct SddBuilderStats {
 
 pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
     // internal data structures
-    fn get_vtree_manager(&self) -> &VTreeManager;
+    fn vtree_manager(&self) -> &VTreeManager;
 
     fn app_cache_get(&self, and: &SddAnd<'a>) -> Option<SddPtr<'a>>;
     fn app_cache_insert(&self, and: SddAnd<'a>, ptr: SddPtr<'a>);
@@ -117,7 +117,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
     /// a is prime to b
     fn and_indep(&'a self, a: SddPtr<'a>, b: SddPtr<'a>, lca: VTreeIndex) -> SddPtr<'a> {
         // check if this is a right-linear fragment and construct the relevant SDD type
-        if self.get_vtree_manager().get_idx(lca).is_right_linear() {
+        if self.vtree_manager().get_idx(lca).is_right_linear() {
             // a is a right-linear decision for b; construct a binary decision
             let bdd = match a {
                 SddPtr::Var(label, true) => BinarySDD::new(label, SddPtr::false_ptr(), b, lca),
@@ -251,7 +251,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
         // check if a and b are both binary SDDs; if so, we apply BDD conjunction here
 
         if let SddPtr::BDD(or) | SddPtr::ComplBDD(or) = a {
-            if self.get_vtree_manager().get_idx(lca).is_right_linear() {
+            if self.vtree_manager().get_idx(lca).is_right_linear() {
                 let l = self.and(a.low(), b.low());
                 let h = self.and(a.high(), b.high());
                 return self.unique_bdd(BinarySDD::new(or.label(), l, h, lca));
@@ -318,28 +318,24 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
 
     // helpers
 
-    fn get_vtree_root(&self) -> &VTree {
-        self.get_vtree_manager().vtree_root()
-    }
-
     fn num_vars(&self) -> usize {
-        self.get_vtree_manager().num_vars()
+        self.vtree_manager().num_vars()
     }
 
-    fn get_vtree(&self, ptr: SddPtr) -> &VTree {
+    fn vtree(&self, ptr: SddPtr) -> &VTree {
         match ptr {
             SddPtr::Var(lbl, _) => {
-                let idx = self.get_vtree_manager().get_varlabel_idx(lbl);
-                self.get_vtree_manager().get_idx(idx)
+                let idx = self.vtree_manager().var_index(lbl);
+                self.vtree_manager().get_idx(idx)
             }
-            SddPtr::Compl(_) | SddPtr::Reg(_) => self.get_vtree_manager().get_idx(ptr.vtree()),
+            SddPtr::Compl(_) | SddPtr::Reg(_) => self.vtree_manager().get_idx(ptr.vtree()),
             _ => panic!("called vtree on constant"),
         }
     }
 
-    fn get_vtree_idx(&self, ptr: SddPtr) -> VTreeIndex {
+    fn vtree_index(&self, ptr: SddPtr) -> VTreeIndex {
         match ptr {
-            SddPtr::Var(lbl, _) => self.get_vtree_manager().get_varlabel_idx(lbl),
+            SddPtr::Var(lbl, _) => self.vtree_manager().var_index(lbl),
             SddPtr::BDD(_) | SddPtr::ComplBDD(_) | SddPtr::Compl(_) | SddPtr::Reg(_) => ptr.vtree(),
             _ => panic!("called vtree on constant"),
         }
@@ -364,7 +360,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
                 .iter()
                 .max_by(|l1, l2| {
                     if self
-                        .get_vtree_manager()
+                        .vtree_manager()
                         .is_prime_var(l1.get_label(), l2.get_label())
                     {
                         Ordering::Less
@@ -377,7 +373,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
                 .iter()
                 .max_by(|l1, l2| {
                     if self
-                        .get_vtree_manager()
+                        .vtree_manager()
                         .is_prime_var(l1.get_label(), l2.get_label())
                     {
                         Ordering::Less
@@ -387,7 +383,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
                 })
                 .unwrap();
             if self
-                .get_vtree_manager()
+                .vtree_manager()
                 .is_prime_var(fst1.get_label(), fst2.get_label())
             {
                 Ordering::Less
@@ -568,10 +564,10 @@ where
         };
 
         // normalize so `a` is always prime if possible
-        let (a, b) = if self.get_vtree_idx(a) == self.get_vtree_idx(b)
+        let (a, b) = if self.vtree_index(a) == self.vtree_index(b)
             || self
-                .get_vtree_manager()
-                .is_prime_index(self.get_vtree_idx(a), self.get_vtree_idx(b))
+                .vtree_manager()
+                .is_prime_index(self.vtree_index(a), self.vtree_index(b))
         {
             (a, b)
         } else {
@@ -583,9 +579,9 @@ where
             return x;
         }
 
-        let av = self.get_vtree_idx(a);
-        let bv = self.get_vtree_idx(b);
-        let lca = self.get_vtree_manager().lca(av, bv);
+        let av = self.vtree_index(a);
+        let bv = self.vtree_index(b);
+        let lca = self.vtree_manager().lca(av, bv);
 
         // now we determine the current iterator for primes and subs
         // consider the following example vtree:
@@ -670,7 +666,7 @@ where
 
     /// Computes the SDD representing the logical function `if f then g else h`
     fn ite(&'a self, f: SddPtr<'a>, g: SddPtr<'a>, h: SddPtr<'a>) -> SddPtr<'a> {
-        let ite = Ite::new(|a, b| self.get_vtree_manager().is_prime(a, b), f, g, h);
+        let ite = Ite::new(|a, b| self.vtree_manager().is_prime(a, b), f, g, h);
         if let Ite::IteConst(f) = ite {
             return f;
         }

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -31,7 +31,7 @@ pub struct CompressionSddBuilder<'a> {
 
 impl<'a> SddBuilder<'a> for CompressionSddBuilder<'a> {
     #[inline]
-    fn get_vtree_manager(&self) -> &VTreeManager {
+    fn vtree_manager(&self) -> &VTreeManager {
         &self.vtree
     }
 
@@ -467,7 +467,7 @@ fn sdd_wmc1() {
     let x_fx = builder.iff(x, fx);
     let y_fy = builder.iff(y, fy);
     let ptr = builder.and(x_fx, y_fy);
-    let wmc_res: RealSemiring = ptr.wmc(builder.get_vtree_manager(), &wmc_map);
+    let wmc_res: RealSemiring = ptr.wmc(builder.vtree_manager(), &wmc_map);
     let expected = RealSemiring(1.0);
     let diff = (wmc_res - expected).0.abs();
     println!("sdd: {}", builder.print_sdd(ptr));

--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -38,7 +38,7 @@ pub struct SemanticSddBuilder<'a, const P: u128> {
 
 impl<'a, const P: u128> SddBuilder<'a> for SemanticSddBuilder<'a, P> {
     #[inline]
-    fn get_vtree_manager(&self) -> &VTreeManager {
+    fn vtree_manager(&self) -> &VTreeManager {
         &self.vtree
     }
 
@@ -260,8 +260,8 @@ fn prob_equiv_sdd_demorgan() {
     let map: WmcParams<FiniteField<{ primes::U32_SMALL }>> =
         create_semantic_hash_map(builder.num_vars());
 
-    let sh1 = res.cached_semantic_hash(builder.get_vtree_manager(), &map);
-    let sh2 = expected.cached_semantic_hash(builder.get_vtree_manager(), &map);
+    let sh1 = res.cached_semantic_hash(builder.vtree_manager(), &map);
+    let sh2 = expected.cached_semantic_hash(builder.vtree_manager(), &map);
 
     assert!(sh1 == sh2, "Not eq:\nGot: {:?}\nExpected: {:?}", sh1, sh2);
 }

--- a/src/plan/bdd_plan.rs
+++ b/src/plan/bdd_plan.rs
@@ -78,11 +78,11 @@ impl BddPlan {
                 if clause.is_empty() {
                     Self::ConstFalse
                 } else if clause.len() == 1 {
-                    Self::literal(clause[0].get_label(), clause[0].get_polarity())
+                    Self::literal(clause[0].label(), clause[0].polarity())
                 } else {
-                    let first_lit = Self::literal(clause[0].get_label(), clause[0].get_polarity());
+                    let first_lit = Self::literal(clause[0].label(), clause[0].polarity());
                     clause.iter().skip(1).fold(first_lit, |acc, i| {
-                        let new_l = Self::literal(i.get_label(), i.get_polarity());
+                        let new_l = Self::literal(i.label(), i.polarity());
                         Self::or(acc, new_l)
                     })
                 }

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -517,8 +517,8 @@ impl<'a> BddPtr<'a> {
         );
         // multiply in weights of all variables in the partial assignment
         for lit in partial_map_assgn.assignment_iter() {
-            let (l, h) = wmc.var_weight(lit.get_label());
-            if lit.get_polarity() {
+            let (l, h) = wmc.var_weight(lit.label());
+            if lit.polarity() {
                 v = v * (*h);
             } else {
                 v = v * (*l);
@@ -735,8 +735,8 @@ impl<'a> BddPtr<'a> {
     {
         let mut partial_join_acc = T::one();
         for lit in partial_join_assgn.assignment_iter() {
-            let (l, h) = wmc.var_weight(lit.get_label());
-            if lit.get_polarity() {
+            let (l, h) = wmc.var_weight(lit.label());
+            if lit.polarity() {
                 partial_join_acc = partial_join_acc * (*h);
             } else {
                 partial_join_acc = partial_join_acc * (*l);

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -499,7 +499,7 @@ impl<'a> BddPtr<'a> {
     ) -> RealSemiring {
         let mut v = self.bdd_fold(
             &|varlabel, low, high| {
-                let (low_w, high_w) = wmc.get_var_weight(varlabel);
+                let (low_w, high_w) = wmc.var_weight(varlabel);
                 match partial_map_assgn.get(varlabel) {
                     None => {
                         if map_vars.contains(varlabel.value_usize()) {
@@ -517,7 +517,7 @@ impl<'a> BddPtr<'a> {
         );
         // multiply in weights of all variables in the partial assignment
         for lit in partial_map_assgn.assignment_iter() {
-            let (l, h) = wmc.get_var_weight(lit.get_label());
+            let (l, h) = wmc.var_weight(lit.get_label());
             if lit.get_polarity() {
                 v = v * (*h);
             } else {
@@ -617,7 +617,7 @@ impl<'a> BddPtr<'a> {
         self.bdd_fold(
             &|varlabel, low: ExpectedUtility, high: ExpectedUtility| {
                 // get True and False weights for VarLabel
-                let (false_w, true_w) = wmc.get_var_weight(varlabel);
+                let (false_w, true_w) = wmc.var_weight(varlabel);
                 // Check if our partial model has already assigned my variable.
                 match partial_decisions.get(varlabel) {
                     // If not...
@@ -735,7 +735,7 @@ impl<'a> BddPtr<'a> {
     {
         let mut partial_join_acc = T::one();
         for lit in partial_join_assgn.assignment_iter() {
-            let (l, h) = wmc.get_var_weight(lit.get_label());
+            let (l, h) = wmc.var_weight(lit.get_label());
             if lit.get_polarity() {
                 partial_join_acc = partial_join_acc * (*h);
             } else {
@@ -746,7 +746,7 @@ impl<'a> BddPtr<'a> {
         let v = self.bdd_fold(
             &|varlabel, low: T, high: T| {
                 // get True and False weights for node VarLabel
-                let (w_l, w_h) = wmc.get_var_weight(varlabel);
+                let (w_l, w_h) = wmc.var_weight(varlabel);
                 // Check if our partial model has already assigned the node.
                 match partial_join_assgn.get(varlabel) {
                     // If not...
@@ -1049,7 +1049,7 @@ impl<'a> BddNode<'a> {
         order: &VarOrder,
         map: &WmcParams<FiniteField<P>>,
     ) -> FiniteField<P> {
-        let (low_w, high_w) = map.get_var_weight(self.var);
+        let (low_w, high_w) = map.var_weight(self.var);
         self.low.cached_semantic_hash(order, map) * (*low_w)
             + self.high.cached_semantic_hash(order, map) * (*high_w)
     }

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -327,7 +327,7 @@ impl<'a> BddPtr<'a> {
     /// Gets the scratch value stored in `&self`
     ///
     /// Panics if not node.
-    pub fn get_scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T> {
+    pub fn scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T> {
         match self {
             Compl(n) | Reg(n) => {
                 if self.is_scratch_cleared() {
@@ -352,7 +352,7 @@ impl<'a> BddPtr<'a> {
     /// Panics if not a node.
     ///
     /// Invariant: values stored in `set_scratch` must not outlive
-    /// the provided allocator `alloc` (i.e., calling `get_scratch`
+    /// the provided allocator `alloc` (i.e., calling `scratch`
     /// involves dereferencing a pointer stored in `alloc`)
     pub fn set_scratch<T: 'static>(&self, v: T) {
         match self {
@@ -461,7 +461,7 @@ impl<'a> BddPtr<'a> {
                     res
                 };
 
-                match self.get_scratch::<(Option<T>, Option<T>)>() {
+                match self.scratch::<(Option<T>, Option<T>)>() {
                     // If complemented and accumulated, use the already memoized value
                     Some((Some(v), _)) if self.is_neg() => v,
                     // Same for not complemented
@@ -964,7 +964,7 @@ impl<'a> DDNNFPtr<'a> for BddPtr<'a> {
                         or_v
                     };
 
-                    match ptr.get_scratch::<DDNNFCache<T>>() {
+                    match ptr.scratch::<DDNNFCache<T>>() {
                         // first, check if cached; explicit arms here for clarity
                         Some((Some(l), Some(h))) => {
                             if ptr.is_neg() {
@@ -994,7 +994,7 @@ impl<'a> DDNNFPtr<'a> for BddPtr<'a> {
             if ptr.is_const() {
                 return;
             }
-            match ptr.get_scratch::<usize>() {
+            match ptr.scratch::<usize>() {
                 Some(_) => (),
                 None => {
                     // found a new node

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -471,7 +471,7 @@ impl Cnf {
         let mut total: T = T::zero();
         let mut weight_vec = Vec::new();
         for i in 0..self.num_vars() {
-            weight_vec.push(weights.get_var_weight(VarLabel::new(i as u64)));
+            weight_vec.push(weights.var_weight(VarLabel::new(i as u64)));
         }
         for assgn in AssignmentIter::new(self.num_vars()) {
             if assgn.is_empty() {

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -84,7 +84,7 @@ pub trait DDNNFPtr<'a>: Clone + Debug + PartialEq + Eq + Hash + Copy {
                 True => params.one,
                 False => params.zero,
                 Lit(lbl, polarity) => {
-                    let (low_w, high_w) = params.get_var_weight(lbl);
+                    let (low_w, high_w) = params.var_weight(lbl);
                     if polarity {
                         *high_w
                     } else {

--- a/src/repr/dtree.rs
+++ b/src/repr/dtree.rs
@@ -105,7 +105,7 @@ impl DTree {
                 vars,
             } => {
                 for c in clause.iter() {
-                    vars.insert(c.get_label());
+                    vars.insert(c.label());
                 }
             }
         }

--- a/src/repr/model.rs
+++ b/src/repr/model.rs
@@ -42,7 +42,7 @@ impl PartialModel {
     pub fn from_litvec(assignments: &[Literal], num_vars: usize) -> PartialModel {
         let mut init_assgn = vec![None; num_vars];
         for assgn in assignments {
-            init_assgn[assgn.get_label().value_usize()] = Some(assgn.get_polarity());
+            init_assgn[assgn.label().value_usize()] = Some(assgn.polarity());
         }
         Self::from_vec(init_assgn)
     }
@@ -75,15 +75,15 @@ impl PartialModel {
     }
 
     pub fn lit_implied(&self, lit: Literal) -> bool {
-        match self.get(lit.get_label()) {
-            Some(v) => v == lit.get_polarity(),
+        match self.get(lit.label()) {
+            Some(v) => v == lit.polarity(),
             None => false,
         }
     }
 
     pub fn lit_neg_implied(&self, lit: Literal) -> bool {
-        match self.get(lit.get_label()) {
-            Some(v) => v != lit.get_polarity(),
+        match self.get(lit.label()) {
+            Some(v) => v != lit.polarity(),
             None => false,
         }
     }

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -84,11 +84,11 @@ impl<'a> SddPtr<'a> {
     }
 
     /// Gets the scratch value stored in `&self`
-    pub fn get_scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T> {
+    pub fn scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T> {
         match self {
             PtrTrue | PtrFalse | Var(_, _) => None,
-            BDD(bdd) | ComplBDD(bdd) => bdd.get_scratch(),
-            Reg(or) | Compl(or) => or.get_scratch(),
+            BDD(bdd) | ComplBDD(bdd) => bdd.scratch(),
+            Reg(or) | Compl(or) => or.scratch(),
         }
     }
 
@@ -97,7 +97,7 @@ impl<'a> SddPtr<'a> {
     /// Panics if not a node.
     ///
     /// Invariant: values stored in `set_scratch` must not outlive
-    /// the provided allocator `alloc` (i.e., calling `get_scratch`
+    /// the provided allocator `alloc` (i.e., calling `scratch`
     /// involves dereferencing a pointer stored in `alloc`)
     pub fn set_scratch<T: 'static>(&self, v: T) {
         match self {
@@ -328,7 +328,7 @@ impl<'a> DDNNFPtr<'a> for SddPtr<'a> {
                         or_v
                     };
 
-                    match ptr.get_scratch::<DDNNFCache<T>>() {
+                    match ptr.scratch::<DDNNFCache<T>>() {
                         // first, check if cached; explicit arms here for clarity
                         Some((Some(l), Some(h))) => {
                             if ptr.is_neg() {
@@ -358,7 +358,7 @@ impl<'a> DDNNFPtr<'a> for SddPtr<'a> {
             if ptr.is_const() || ptr.is_var() {
                 return 0;
             }
-            match ptr.get_scratch::<usize>() {
+            match ptr.scratch::<usize>() {
                 Some(_) => 0,
                 None => {
                     // found a new node

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -70,7 +70,7 @@ impl<'a> SddPtr<'a> {
             PtrTrue => FiniteField::new(1),
             PtrFalse => FiniteField::new(0),
             Var(label, polarity) => {
-                let (l_w, h_w) = map.get_var_weight(*label);
+                let (l_w, h_w) = map.var_weight(*label);
                 if *polarity {
                     *h_w
                 } else {
@@ -433,7 +433,7 @@ fn is_compressed_simple_bdd() {
         VarLabel::new(2),
         a,
         b,
-        vtree_manager.get_varlabel_idx(VarLabel::new(2)),
+        vtree_manager.var_index(VarLabel::new(2)),
     );
     let binary_sdd_ptr = &mut binary_sdd;
     let bdd_ptr = SddPtr::BDD(binary_sdd_ptr);
@@ -453,7 +453,7 @@ fn is_compressed_simple_bdd_duplicate() {
         VarLabel::new(2),
         a,
         a, // duplicate with low - not compressed!
-        vtree_manager.get_varlabel_idx(VarLabel::new(2)),
+        vtree_manager.var_index(VarLabel::new(2)),
     );
     let binary_sdd_ptr = &mut binary_sdd;
     let bdd_ptr = SddPtr::BDD(binary_sdd_ptr);

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -111,7 +111,7 @@ impl<'a> SddPtr<'a> {
         match self {
             PtrTrue | PtrFalse | Var(_, _) => true,
             BDD(bdd) | ComplBDD(bdd) => bdd.is_scratch_cleared(),
-            Reg(or) | Compl(or) => or.scratch.borrow().is_none(),
+            Reg(or) | Compl(or) => or.is_scratch_cleared(),
         }
     }
 

--- a/src/repr/sdd/binary_sdd.rs
+++ b/src/repr/sdd/binary_sdd.rs
@@ -69,7 +69,7 @@ impl<'a> BinarySDD<'a> {
         vtree: &VTreeManager,
         map: &WmcParams<FiniteField<P>>,
     ) -> FiniteField<P> {
-        let (low_w, high_w) = map.get_var_weight(self.label());
+        let (low_w, high_w) = map.var_weight(self.label());
         self.low().cached_semantic_hash(vtree, map) * (*low_w)
             + self.high().cached_semantic_hash(vtree, map) * (*high_w)
     }

--- a/src/repr/sdd/binary_sdd.rs
+++ b/src/repr/sdd/binary_sdd.rs
@@ -89,7 +89,7 @@ impl<'a> BinarySDD<'a> {
         h
     }
 
-    pub fn get_scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T>
+    pub fn scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T>
     where
         T: Clone,
     {

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -66,7 +66,7 @@ impl<'a> SddOr<'a> {
         h
     }
 
-    pub fn get_scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T>
+    pub fn scratch<T: ?Sized + Clone + 'static>(&self) -> Option<T>
     where
         T: Clone,
     {

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -19,8 +19,8 @@ pub struct SddOr<'a> {
     pub nodes: Vec<SddAnd<'a>>,
 
     // scratch
-    pub scratch: RefCell<Option<Box<dyn Any>>>,
-    pub semantic_hash: RefCell<Option<u128>>,
+    scratch: RefCell<Option<Box<dyn Any>>>,
+    semantic_hash: RefCell<Option<u128>>,
 }
 
 impl<'a> SddOr<'a> {

--- a/src/repr/unit_prop.rs
+++ b/src/repr/unit_prop.rs
@@ -104,15 +104,15 @@ impl UnitPropagate {
                 implied.push(c[0]);
                 continue;
             }
-            if c[1].get_polarity() {
-                watch_list_pos[c[1].get_label().value() as usize].push(idx)
+            if c[1].polarity() {
+                watch_list_pos[c[1].label().value() as usize].push(idx)
             } else {
-                watch_list_neg[c[1].get_label().value() as usize].push(idx)
+                watch_list_neg[c[1].label().value() as usize].push(idx)
             }
-            if c[0].get_polarity() {
-                watch_list_pos[c[0].get_label().value() as usize].push(idx)
+            if c[0].polarity() {
+                watch_list_pos[c[0].label().value() as usize].push(idx)
             } else {
-                watch_list_neg[c[0].get_label().value() as usize].push(idx)
+                watch_list_neg[c[0].label().value() as usize].push(idx)
             }
         }
 
@@ -140,10 +140,10 @@ impl UnitPropagate {
     /// returns true if success, false if UNSAT
     fn decide(&mut self, mut cur_state: PartialModel, new_assignment: Literal) -> UnitPropResult {
         // if already assigned, check if consistent -- if not, return unsat
-        match cur_state.get(new_assignment.get_label()) {
+        match cur_state.get(new_assignment.label()) {
             None => (),
             Some(v) => {
-                if v == new_assignment.get_polarity() {
+                if v == new_assignment.polarity() {
                     return UnitPropResult::PartialSAT(cur_state);
                 } else {
                     return UnitPropResult::UNSAT;
@@ -152,9 +152,9 @@ impl UnitPropagate {
         };
 
         // update the value of the decided variable in the partial model
-        cur_state.set(new_assignment.get_label(), new_assignment.get_polarity());
+        cur_state.set(new_assignment.label(), new_assignment.polarity());
 
-        let var_idx = new_assignment.get_label().value() as usize;
+        let var_idx = new_assignment.label().value() as usize;
 
         // track a list of all discovered implications
         // indexes over the watchers for the current literal
@@ -164,14 +164,14 @@ impl UnitPropagate {
         loop {
             // first check if there are any watchers; if no watchers left, break
 
-            if new_assignment.get_polarity() {
+            if new_assignment.polarity() {
                 if watcher_idx >= self.watch_list_neg[var_idx].len() {
                     break;
                 }
             } else if watcher_idx >= self.watch_list_pos[var_idx].len() {
                 break;
             }
-            let clause = if new_assignment.get_polarity() {
+            let clause = if new_assignment.polarity() {
                 &self.cnf.clauses()[self.watch_list_neg[var_idx][watcher_idx]]
             } else {
                 &self.cnf.clauses()[self.watch_list_pos[var_idx][watcher_idx]]
@@ -181,8 +181,8 @@ impl UnitPropagate {
             // move onto the next watcher
             let mut is_sat = false;
             for lit in clause.iter() {
-                match cur_state.get(lit.get_label()) {
-                    Some(v) if lit.get_polarity() == v => {
+                match cur_state.get(lit.label()) {
+                    Some(v) if lit.polarity() == v => {
                         watcher_idx += 1;
                         is_sat = true;
                         break;
@@ -195,9 +195,7 @@ impl UnitPropagate {
             }
 
             // gather a list of all remaining unassigned literals in the current clause
-            let mut remaining_lits = clause
-                .iter()
-                .filter(|x| cur_state.get(x.get_label()).is_none());
+            let mut remaining_lits = clause.iter().filter(|x| cur_state.get(x.label()).is_none());
 
             let num_remaining = remaining_lits.clone().count();
             if num_remaining == 0 {
@@ -217,21 +215,17 @@ impl UnitPropagate {
             } else {
                 // num_remaining > 1, find a new literal to watch
                 // first, find a new literal to watch
-                let candidate_unwatched: LitIdx = remaining_lits
-                    .clone()
-                    .next()
-                    .unwrap()
-                    .get_label()
-                    .value_usize();
+                let candidate_unwatched: LitIdx =
+                    remaining_lits.clone().next().unwrap().label().value_usize();
                 // check if candidate_unwatched is already being watched; if it
                 // is, pick another literal to watch
-                let prev_watcher: ClauseIdx = if new_assignment.get_polarity() {
+                let prev_watcher: ClauseIdx = if new_assignment.polarity() {
                     self.watch_list_neg[var_idx][watcher_idx]
                 } else {
                     self.watch_list_pos[var_idx][watcher_idx]
                 };
 
-                let new_lit: &Literal = if new_assignment.get_polarity() {
+                let new_lit: &Literal = if new_assignment.polarity() {
                     if self.watch_list_pos[candidate_unwatched].contains(&prev_watcher) {
                         remaining_lits.nth(1).unwrap()
                     } else {
@@ -243,16 +237,16 @@ impl UnitPropagate {
                     remaining_lits.next().unwrap()
                 };
 
-                let new_loc = new_lit.get_label().value_usize();
+                let new_loc = new_lit.label().value_usize();
 
-                if new_assignment.get_polarity() {
+                if new_assignment.polarity() {
                     self.watch_list_neg[var_idx].swap_remove(watcher_idx);
                 } else {
                     self.watch_list_pos[var_idx].swap_remove(watcher_idx);
                 };
 
                 // now add the new one
-                if new_lit.get_polarity() {
+                if new_lit.polarity() {
                     self.watch_list_pos[new_loc].push(prev_watcher);
                 } else {
                     self.watch_list_neg[new_loc].push(prev_watcher);
@@ -307,18 +301,18 @@ impl SATSolver {
 
         // first handle subsumed clause case (case 2)
         for lit in new_model.difference(&self.top_state().model) {
-            let matching_polarity = if lit.get_polarity() {
+            let matching_polarity = if lit.polarity() {
                 &self.contains_pos_lit
             } else {
                 &self.contains_neg_lit
             };
-            for clause_idx in matching_polarity[lit.get_label().value_usize()].iter() {
+            for clause_idx in matching_polarity[lit.label().value_usize()].iter() {
                 if new_set.contains(clause_idx) {
                     continue;
                 }
                 new_set.insert(clause_idx);
                 for (clause_lit, weight) in self.clauses[clause_idx].iter() {
-                    if !self.top_state().model.is_set(clause_lit.get_label()) {
+                    if !self.top_state().model.is_set(clause_lit.label()) {
                         hash = hash.wrapping_mul(*weight);
                     }
                 }
@@ -327,18 +321,18 @@ impl SATSolver {
 
         // now handle case 3
         for lit in new_model.difference(&self.top_state().model) {
-            let opposite_polarity = if lit.get_polarity() {
+            let opposite_polarity = if lit.polarity() {
                 &self.contains_neg_lit
             } else {
                 &self.contains_pos_lit
             };
-            for clause_idx in opposite_polarity[lit.get_label().value_usize()].iter() {
+            for clause_idx in opposite_polarity[lit.label().value_usize()].iter() {
                 if new_set.contains(clause_idx) {
                     // avoid double-counting
                     continue;
                 }
                 for (clause_lit, weight) in self.clauses[clause_idx].iter() {
-                    if clause_lit.get_label() == lit.get_label() {
+                    if clause_lit.label() == lit.label() {
                         hash = hash.wrapping_mul(*weight);
                         break;
                     }
@@ -371,8 +365,8 @@ impl SATSolver {
                 let i = clauses.iter().filter(|clause| {
                     for i in 0..clause.len() {
                         for j in (i + 1)..clause.len() {
-                            if clause[i].get_label() == clause[j].get_label()
-                                && clause[i].get_polarity() != clause[j].get_polarity()
+                            if clause[i].label() == clause[j].label()
+                                && clause[i].polarity() != clause[j].polarity()
                             {
                                 return false;
                             }
@@ -404,10 +398,10 @@ impl SATSolver {
 
                 for (clause_idx, clause) in clauses.iter().enumerate() {
                     for lit in clause.iter() {
-                        if lit.0.get_polarity() {
-                            pos_lit[lit.0.get_label().value_usize()].insert(clause_idx);
+                        if lit.0.polarity() {
+                            pos_lit[lit.0.label().value_usize()].insert(clause_idx);
                         } else {
-                            neg_lit[lit.0.get_label().value_usize()].insert(clause_idx);
+                            neg_lit[lit.0.label().value_usize()].insert(clause_idx);
                         }
                     }
                 }
@@ -476,7 +470,7 @@ impl SATSolver {
             .difference(&self.state_stack[self.state_stack.len() - 2].model)
     }
 
-    pub fn get_cur_hash(&self) -> u128 {
+    pub fn cur_hash(&self) -> u128 {
         self.top_state().hash
     }
 

--- a/src/repr/unit_prop.rs
+++ b/src/repr/unit_prop.rs
@@ -470,7 +470,7 @@ impl SATSolver {
 
     /// Get an iterator over the difference between the units implied at
     /// the top and second-to-top decision
-    pub fn get_difference(&self) -> impl Iterator<Item = Literal> + '_ {
+    pub fn difference_iter(&self) -> impl Iterator<Item = Literal> + '_ {
         self.top_state()
             .model
             .difference(&self.state_stack[self.state_stack.len() - 2].model)

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -36,8 +36,8 @@ pub struct Literal {
 }
 
 BITFIELD!(Literal data : u64 [
-    label set_label[0..63],
-    polarity set_polarity[63..64],
+    raw_label set_label[0..63],
+    raw_polarity set_polarity[63..64],
 ]);
 
 impl Literal {
@@ -59,10 +59,10 @@ impl Literal {
     ///
     /// let lit = Literal::new(VarLabel::new(0), true);
     ///
-    /// assert_eq!(lit.get_label(), VarLabel::new(0))
+    /// assert_eq!(lit.label(), VarLabel::new(0))
     /// ```
-    pub fn get_label(&self) -> VarLabel {
-        VarLabel(self.label())
+    pub fn label(&self) -> VarLabel {
+        VarLabel(self.raw_label())
     }
 
     /// ```
@@ -71,11 +71,11 @@ impl Literal {
     /// let lit1 = Literal::new(VarLabel::new(0), true);
     /// let lit2 = Literal::new(VarLabel::new(0), false);
     ///
-    /// assert!(lit1.get_polarity());
-    /// assert!(!lit2.get_polarity());
+    /// assert!(lit1.polarity());
+    /// assert!(!lit2.polarity());
     /// ```
-    pub fn get_polarity(&self) -> bool {
-        self.polarity() == 1
+    pub fn polarity(&self) -> bool {
+        self.raw_polarity() == 1
     }
 
     /// ```
@@ -87,7 +87,7 @@ impl Literal {
     /// assert!(lit1.implies_true(&lit2));
     /// ```
     pub fn implies_true(&self, other: &Literal) -> bool {
-        self.get_label() == other.get_label() && self.get_polarity() == other.get_polarity()
+        self.label() == other.label() && self.polarity() == other.polarity()
     }
 
     /// ```
@@ -99,7 +99,7 @@ impl Literal {
     /// assert!(lit1.implies_false(&lit2));
     /// ```
     pub fn implies_false(&self, other: &Literal) -> bool {
-        self.get_label() == other.get_label() && self.get_polarity() != other.get_polarity()
+        self.label() == other.label() && self.polarity() != other.polarity()
     }
 
     /// ```
@@ -111,15 +111,15 @@ impl Literal {
     /// assert_eq!(lit1.negated(), lit2);
     /// ```
     pub fn negated(&self) -> Literal {
-        Literal::new(self.get_label(), !self.get_polarity())
+        Literal::new(self.label(), !self.polarity())
     }
 }
 
 impl fmt::Debug for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Literal")
-            .field("label", &self.get_label())
-            .field("polarity", &self.get_polarity())
+            .field("label", &self.label())
+            .field("polarity", &self.polarity())
             .finish()
     }
 }

--- a/src/repr/var_order.rs
+++ b/src/repr/var_order.rs
@@ -195,11 +195,6 @@ impl VarOrder {
         }
     }
 
-    /// Produces a vector of variable positions indexed by
-    pub fn get_var_to_pos_vec(&self) -> Vec<usize> {
-        self.var_to_pos.clone()
-    }
-
     /// Gets the variable that occurs last in the order
     /// ```
     /// # use rsdd::repr::var_order::VarOrder;

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -31,12 +31,12 @@ impl VTree {
         }
     }
 
-    pub fn get_all_vars(&self) -> HashSet<usize> {
+    pub fn all_vars(&self) -> HashSet<usize> {
         match self {
             BTree::Leaf(v) => HashSet::from([v.value_usize()]),
             BTree::Node((), l, r) => {
-                let lvar = l.get_all_vars();
-                let rvar = r.get_all_vars();
+                let lvar = l.all_vars();
+                let rvar = r.all_vars();
                 &lvar | &rvar
             }
         }
@@ -309,7 +309,7 @@ pub struct VTreeManager {
     /// a mapping from BFS indexes to DFS indexes
     bfs_to_dfs: Vec<usize>,
     /// maps an Sdd VarLabel into its vtree index in the depth-first order
-    vtree_idx: Vec<usize>,
+    vtree_index: Vec<usize>,
     index_lookup: Vec<VTree>,
     lca: LeastCommonAncestor,
 }
@@ -333,7 +333,7 @@ impl VTreeManager {
             dfs_to_bfs: tree.dfs_to_bfs_mapping(),
             bfs_to_dfs: tree.bfs_to_dfs_mapping(),
             index_lookup,
-            vtree_idx: vtree_lookup,
+            vtree_index: vtree_lookup,
             lca: LeastCommonAncestor::new(&tree),
             tree,
         }
@@ -358,19 +358,19 @@ impl VTreeManager {
 
     /// Find the index into self.vtree that contains the label `lbl`
     /// panics if this does not exist.
-    pub fn get_varlabel_idx(&self, lbl: VarLabel) -> VTreeIndex {
-        VTreeIndex(self.vtree_idx[lbl.value_usize()])
+    pub fn var_index(&self, lbl: VarLabel) -> VTreeIndex {
+        VTreeIndex(self.vtree_index[lbl.value_usize()])
     }
 
     /// true if a is prime to b
     /// panics if either is constant
     pub fn is_prime(&self, a: SddPtr, b: SddPtr) -> bool {
         let a_vtree = match a {
-            SddPtr::Var(label, _) => self.get_varlabel_idx(label),
+            SddPtr::Var(label, _) => self.var_index(label),
             _ => a.vtree(),
         };
         let b_vtree = match b {
-            SddPtr::Var(label, _) => self.get_varlabel_idx(label),
+            SddPtr::Var(label, _) => self.var_index(label),
             _ => b.vtree(),
         };
         self.is_prime_index(a_vtree, b_vtree)
@@ -379,7 +379,7 @@ impl VTreeManager {
     /// true if a is prime to b
     /// panics if either is constant
     pub fn is_prime_var(&self, a: VarLabel, b: VarLabel) -> bool {
-        self.is_prime_index(self.get_varlabel_idx(a), self.get_varlabel_idx(b))
+        self.is_prime_index(self.var_index(a), self.var_index(b))
     }
 
     /// true if the vtree index `l` is prime to `r`
@@ -392,7 +392,7 @@ impl VTreeManager {
 
     /// produces the number of variables allocated by this vtree
     pub fn num_vars(&self) -> usize {
-        self.vtree_root().get_all_vars().into_iter().max().unwrap()
+        self.vtree_root().all_vars().into_iter().max().unwrap()
     }
 }
 

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -352,7 +352,7 @@ impl VTreeManager {
     }
 
     /// Given a vtree index, produce a pointer to the vtree this corresponds with
-    pub fn get_idx(&self, idx: VTreeIndex) -> &VTree {
+    pub fn vtree(&self, idx: VTreeIndex) -> &VTree {
         &(self.index_lookup[idx.0])
     }
 

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -74,10 +74,10 @@ impl<T: Semiring> WmcParams<T> {
     pub fn assignment_weight(&self, assgn: &[Literal]) -> T {
         let mut prod = self.one;
         for lit in assgn.iter() {
-            if lit.get_polarity() {
-                prod = prod * self.var_to_val[lit.get_label().value_usize()].unwrap().1
+            if lit.polarity() {
+                prod = prod * self.var_to_val[lit.label().value_usize()].unwrap().1
             } else {
-                prod = prod * self.var_to_val[lit.get_label().value_usize()].unwrap().0
+                prod = prod * self.var_to_val[lit.label().value_usize()].unwrap().0
             }
         }
         prod

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -36,7 +36,7 @@ impl<T: Semiring> WmcParams<T> {
     ///     Literal::new(VarLabel::new(1), true),
     /// ];
     ///
-    /// assert_eq!(params.get_weight(&all_true).0, 0.7)
+    /// assert_eq!(params.assignment_weight(&all_true).0, 0.7)
     /// ```
     pub fn new(var_to_val: HashMap<VarLabel, (T, T)>) -> WmcParams<T> {
         let mut var_to_val_vec: Vec<Option<(T, T)>> = vec![None; var_to_val.len()];
@@ -69,9 +69,9 @@ impl<T: Semiring> WmcParams<T> {
     ///     Literal::new(VarLabel::new(1), true),
     /// ];
     ///
-    /// assert_eq!(params.get_weight(&all_true).0, 0.7)
+    /// assert_eq!(params.assignment_weight(&all_true).0, 0.7)
     /// ```
-    pub fn get_weight(&self, assgn: &[Literal]) -> T {
+    pub fn assignment_weight(&self, assgn: &[Literal]) -> T {
         let mut prod = self.one;
         for lit in assgn.iter() {
             if lit.get_polarity() {
@@ -101,10 +101,10 @@ impl<T: Semiring> WmcParams<T> {
     ///     Literal::new(VarLabel::new(1), true),
     /// ];
     ///
-    /// assert_eq!(params.get_weight(&all_true).0, 0.7);
+    /// assert_eq!(params.assignment_weight(&all_true).0, 0.7);
     ///
     /// params.set_weight(VarLabel::new(1), RealSemiring(0.5), RealSemiring(0.5));
-    /// assert_eq!(params.get_weight(&all_true).0, 0.5);
+    /// assert_eq!(params.assignment_weight(&all_true).0, 0.5);
     /// ```
     pub fn set_weight(&mut self, lbl: VarLabel, low: T, high: T) {
         let n = lbl.value_usize();
@@ -127,10 +127,10 @@ impl<T: Semiring> WmcParams<T> {
     ///
     /// let params = WmcParams::<RealSemiring>::new(weights);
     ///
-    /// assert_eq!(*params.get_var_weight(VarLabel::new(1)), (RealSemiring(0.3), RealSemiring(0.7)))
+    /// assert_eq!(*params.var_weight(VarLabel::new(1)), (RealSemiring(0.3), RealSemiring(0.7)))
     /// ```
     // gives you the weight of `(low, high)` literals for a given VarLabel
-    pub fn get_var_weight(&self, label: VarLabel) -> &(T, T) {
+    pub fn var_weight(&self, label: VarLabel) -> &(T, T) {
         return (self.var_to_val[label.value_usize()]).as_ref().unwrap();
     }
 }

--- a/src/sample/importance_sampler.rs
+++ b/src/sample/importance_sampler.rs
@@ -16,7 +16,7 @@ pub trait ImportanceSampler<Sample: std::fmt::Debug + Clone, State: std::fmt::De
 
     /// Gives a unique index that corresponds to this particular state
     /// Used for automated testing, this can be inefficient
-    fn get_state_index(&self, state: &State) -> usize;
+    fn state_index(&self, state: &State) -> usize;
 
     /// Generates a vector of the probability of every state indexed by the
     /// state index

--- a/src/util/hypergraph.rs
+++ b/src/util/hypergraph.rs
@@ -235,7 +235,7 @@ pub fn from_cnf(cnf: &Cnf) -> Hypergraph<VarLabel> {
         let hedge = clause
             .iter()
             .map(|l| {
-                let var = l.get_label();
+                let var = l.label();
                 vars.insert(var);
                 var
             })

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -102,7 +102,7 @@ pub fn demo_model_count_sdd(cnf_input: String) -> Result<JsValue, JsValue> {
 
     let mut params: WmcParams<FiniteField<{ primes::U32_TINY }>> = WmcParams::default();
 
-    for v in 0..builder.get_vtree_manager().num_vars() + 1 {
+    for v in 0..builder.vtree_manager().num_vars() + 1 {
         params.set_weight(
             VarLabel::new_usize(v),
             FiniteField::new(1),
@@ -110,7 +110,7 @@ pub fn demo_model_count_sdd(cnf_input: String) -> Result<JsValue, JsValue> {
         )
     }
 
-    let model_count = sdd.wmc(builder.get_vtree_manager(), &params);
+    let model_count = sdd.wmc(builder.vtree_manager(), &params);
 
     let res = SddModelCountResult {
         model_count: model_count.value(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -185,7 +185,7 @@ p cnf 2 1
 2 3 4 5 6 7 8 0
 ";
 
-fn get_canonical_forms() -> Vec<(Cnf, Cnf)> {
+fn canonical_forms() -> Vec<(Cnf, Cnf)> {
     vec![
         (Cnf::from_dimacs(C1_A), Cnf::from_dimacs(C1_B)),
         (Cnf::from_dimacs(C2_A), Cnf::from_dimacs(C2_B)),
@@ -206,7 +206,7 @@ fn get_canonical_forms() -> Vec<(Cnf, Cnf)> {
 
 #[test]
 fn test_bdd_canonicity() {
-    for (cnf1, cnf2) in get_canonical_forms().into_iter() {
+    for (cnf1, cnf2) in canonical_forms().into_iter() {
         let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf1.num_vars());
         let r1 = builder.compile_cnf(&cnf1);
         let r2 = builder.compile_cnf(&cnf2);
@@ -223,7 +223,7 @@ fn test_bdd_canonicity() {
 
 #[test]
 fn test_sdd_canonicity() {
-    for (cnf1, cnf2) in get_canonical_forms().into_iter() {
+    for (cnf1, cnf2) in canonical_forms().into_iter() {
         let v: Vec<VarLabel> = (0..cnf1.num_vars())
             .map(|x| VarLabel::new(x as u64))
             .collect();
@@ -244,7 +244,7 @@ fn test_sdd_canonicity() {
 
 #[test]
 fn test_sdd_is_canonical() {
-    for (cnf1, cnf2) in get_canonical_forms().into_iter() {
+    for (cnf1, cnf2) in canonical_forms().into_iter() {
         let v: Vec<VarLabel> = (0..cnf1.num_vars())
             .map(|x| VarLabel::new(x as u64))
             .collect();
@@ -371,7 +371,7 @@ mod test_bdd_builder {
             let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
             let weight = create_semantic_hash_map::<{primes::U32_SMALL}>(c1.num_vars());
             let cnf1 = builder.compile_cnf(&c1);
-            let bddres = cnf1.wmc(builder.get_order(), &weight);
+            let bddres = cnf1.wmc(builder.order(), &weight);
             let cnfres = c1.wmc(&weight);
             TestResult::from_bool(bddres == cnfres)
         }
@@ -385,7 +385,7 @@ mod test_bdd_builder {
             let map : WmcParams<rsdd::util::semirings::FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(c1.num_vars());
             let bdd = bdd_builder.compile_cnf(&c1);
             let sdd = sdd_builder.compile_cnf(&c1);
-            bdd.semantic_hash(bdd_builder.get_order(), &map) == sdd.semantic_hash(sdd_builder.get_vtree_manager(), &map)
+            bdd.semantic_hash(bdd_builder.order(), &map) == sdd.semantic_hash(sdd_builder.vtree_manager(), &map)
         }
     }
 
@@ -401,7 +401,7 @@ mod test_bdd_builder {
             let map : WmcParams<rsdd::util::semirings::FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(c1.num_vars());
             let bdd = bdd_builder.compile_cnf(&c1);
             let sdd = sdd_builder.compile_cnf(&c1);
-            bdd.semantic_hash(bdd_builder.get_order(), &map) == sdd.semantic_hash(sdd_builder.get_vtree_manager(), &map)
+            bdd.semantic_hash(bdd_builder.order(), &map) == sdd.semantic_hash(sdd_builder.vtree_manager(), &map)
         }
     }
 
@@ -421,8 +421,8 @@ mod test_bdd_builder {
             let dnnf = builder2.compile_cnf_topdown(&c1);
 
             let bddwmc = super::repr::wmc::WmcParams::new(weight_map);
-            let bddres = cnf1.wmc(builder.get_order(),  &bddwmc);
-            let dnnfres = dnnf.wmc(builder.get_order(), &bddwmc);
+            let bddres = cnf1.wmc(builder.order(),  &bddwmc);
+            let dnnfres = dnnf.wmc(builder.order(), &bddwmc);
             let eps = f64::abs(bddres.0 - dnnfres.0) < 0.0001;
             if !eps {
               println!("error on input {}: bddres {}, cnfres {}\n topdown bdd: {}\nbottom-up bdd: {}",
@@ -444,8 +444,8 @@ mod test_bdd_builder {
             let bddwmc = super::repr::wmc::WmcParams::new(weight_map);
             let cnf1 = builder1.compile_cnf(&c1);
             let cnf2 = builder2.compile_cnf(&c1);
-            let wmc1 = cnf1.wmc(builder1.get_order(), &bddwmc);
-            let wmc2 = cnf2.wmc(builder2.get_order(), &bddwmc);
+            let wmc1 = cnf1.wmc(builder1.order(), &bddwmc);
+            let wmc2 = cnf2.wmc(builder2.order(), &bddwmc);
             TestResult::from_bool(f64::abs(wmc1.0 - wmc2.0) < 0.00001)
         }
     }
@@ -483,7 +483,7 @@ mod test_bdd_builder {
                 let mut conj = builder.and(x, y);
                 conj = builder.and(conj, z);
                 conj = builder.and(conj, cnf);
-                let poss_max = conj.wmc(builder.get_order(), &wmc);
+                let poss_max = conj.wmc(builder.order(), &wmc);
                 if poss_max.0 > max {
                     max = poss_max.0;
                     max_assgn.set(VarLabel::new(0), *v1);
@@ -513,7 +513,7 @@ mod test_bdd_builder {
             let mut conj = builder.and(v0, v1);
             conj = builder.and(conj, v2);
             conj = builder.and(conj, cnf);
-            let poss_max = conj.wmc(builder.get_order(), &wmc);
+            let poss_max = conj.wmc(builder.order(), &wmc);
             if f64::abs(poss_max.0 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -523,7 +523,7 @@ mod test_bdd_builder {
             let mut conj2 = builder.and(w0, w1);
             conj2 = builder.and(conj2, w2);
             builder.and(conj2, cnf);
-            let poss_max2 = conj.wmc(builder.get_order(), &wmc);
+            let poss_max2 = conj.wmc(builder.order(), &wmc);
             if f64::abs(poss_max2.0 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -593,7 +593,7 @@ mod test_bdd_builder {
                 let mut conj = builder.and(x, y);
                 conj = builder.and(conj, z);
                 conj = builder.and(conj, cnf);
-                let poss_max = conj.wmc(builder.get_order(), &wmc);
+                let poss_max = conj.wmc(builder.order(), &wmc);
                 if poss_max.1 > max {
                     max = poss_max.1;
                     max_assgn.set(decisions[0], *v1);
@@ -628,7 +628,7 @@ mod test_bdd_builder {
             let mut conj = builder.and(v0, v1);
             conj = builder.and(conj, v2);
             conj = builder.and(conj, cnf);
-            let poss_max = conj.wmc(builder.get_order(), &wmc);
+            let poss_max = conj.wmc(builder.order(), &wmc);
             if f64::abs(poss_max.1 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -638,7 +638,7 @@ mod test_bdd_builder {
             let mut conj2 = builder.and(w0, w1);
             conj2 = builder.and(conj2, w2);
             builder.and(conj2, cnf);
-            let poss_max2 = conj.wmc(builder.get_order(), &wmc);
+            let poss_max2 = conj.wmc(builder.order(), &wmc);
             if f64::abs(poss_max2.1 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -659,7 +659,7 @@ mod test_bdd_builder {
             // they are with the property that pos_weight + neg_weight = 1
             let map = create_semantic_hash_map::<{primes::U32_SMALL}>(cnf.num_vars());
 
-            bdd.semantic_hash(builder.get_order(), &map) == smoothed.semantic_hash(builder.get_order(), &map)
+            bdd.semantic_hash(builder.order(), &map) == smoothed.semantic_hash(builder.order(), &map)
         }
     }
 }
@@ -759,12 +759,12 @@ mod test_sdd_builder {
            let order : Vec<VarLabel> = (0..cnf.num_vars()).map(|x| VarLabel::new(x as u64)).collect();
            let builder = super::CompressionSddBuilder::new(VTree::even_split(&order, 3));
            let cnf_sdd = builder.compile_cnf(&cnf);
-           let sdd_res = cnf_sdd.semantic_hash(builder.get_vtree_manager(), &weight_map);
+           let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
 
 
             let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
-            let bdd_res = cnf_bdd.semantic_hash(bdd_builder.get_order(), &weight_map);
+            let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
             assert_eq!(bdd_res, sdd_res);
             TestResult::passed()
         }
@@ -784,12 +784,12 @@ mod test_sdd_builder {
             let weight_map = create_semantic_hash_map::<{primes::U32_SMALL}>(cnf.num_vars());
             let builder = super::CompressionSddBuilder::new(vtree);
             let cnf_sdd = builder.compile_cnf(&cnf);
-            let sdd_res = cnf_sdd.semantic_hash(builder.get_vtree_manager(), &weight_map);
+            let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
 
 
             let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
-            let bdd_res = cnf_bdd.semantic_hash(bdd_builder.get_order(), &weight_map);
+            let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
             assert_eq!(bdd_res, sdd_res);
             TestResult::passed()
         }
@@ -872,8 +872,8 @@ mod test_sdd_builder {
 
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>> = create_semantic_hash_map(builder1.num_vars());
 
-            let h1 = c1.semantic_hash(builder1.get_vtree_manager(), &map);
-            let h2 = c2.semantic_hash(builder2.get_vtree_manager(), &map);
+            let h1 = c1.semantic_hash(builder1.vtree_manager(), &map);
+            let h2 = c2.semantic_hash(builder2.vtree_manager(), &map);
 
             h1 == h2
         }
@@ -899,8 +899,8 @@ mod test_sdd_builder {
 
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>> = create_semantic_hash_map(compr_builder.num_vars());
 
-            let compr_h = compr_cnf.semantic_hash(compr_builder.get_vtree_manager(), &map);
-            let uncompr_h = uncompr_cnf.semantic_hash(uncompr_builder.get_vtree_manager(), &map);
+            let compr_h = compr_cnf.semantic_hash(compr_builder.vtree_manager(), &map);
+            let uncompr_h = uncompr_cnf.semantic_hash(uncompr_builder.vtree_manager(), &map);
 
             if compr_h != uncompr_h {
                 println!("not equal! hashes: compr: {compr_h}, uncompr: {uncompr_h}");
@@ -985,7 +985,7 @@ mod test_sdd_builder {
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(builder.num_vars());
             let mut seen_hashes : HashMap<u128, SddPtr> = HashMap::new();
             for sdd in builder.node_iter() {
-                let hash = sdd.semantic_hash(builder.get_vtree_manager(), &map);
+                let hash = sdd.semantic_hash(builder.vtree_manager(), &map);
                 if seen_hashes.contains_key(&hash.value()) {
                     let c = seen_hashes.get(&hash.value()).unwrap();
                     println!("cnf: {}", c1);
@@ -1011,7 +1011,7 @@ mod test_sdd_builder {
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(builder.num_vars());
             let mut seen_hashes : HashMap<u128, SddPtr> = HashMap::new();
             for sdd in builder.node_iter() {
-                let hash = sdd.semantic_hash(builder.get_vtree_manager(), &map);
+                let hash = sdd.semantic_hash(builder.vtree_manager(), &map);
 
                 // see the hash itself
                 if seen_hashes.contains_key(&hash.value()) {
@@ -1063,8 +1063,8 @@ mod test_sdd_builder {
             let sdd = builder.compile_cnf(&c1);
             let compl = sdd.neg();
 
-            let sdd_hash = sdd.semantic_hash(builder.get_vtree_manager(), &map);
-            let compl_hash = compl.semantic_hash(builder.get_vtree_manager(), &map);
+            let sdd_hash = sdd.semantic_hash(builder.vtree_manager(), &map);
+            let compl_hash = compl.semantic_hash(builder.vtree_manager(), &map);
 
             let sum = (sdd_hash + compl_hash).value();
 


### PR DESCRIPTION
See: https://rust-lang.github.io/api-guidelines/naming.html.

Areas of changes:
- removing `get_`, convert `idx` -> `index`
    - `BinarySdd::get_scratch()` -> `BinarySdd::scratch()`
    - `BottomUpBuilder::get_vtree()` -> `BottomUpBuilder::vtree()`
    - `BottomUpBuilder::get_vtree_idx()` -> `BottomUpBuilder::vtree_index()`
    - `BottomUpBuilder::get_vtree_manager()` -> `BottomUpBuilder::vtree_manager()`
    - `Cnf::get_hasher()` -> `Cnf::hasher()`
    - `ImportanceSampler::get_state_index()` -> `ImportanceSampler::state_index()`
    - `RobddBuilder::get_order()` -> `RobddBuilder::order()`
    - `SatSolver::get_cur_hash()` -> `SatSolver::cur_hash()`
    - `SatSolver::get_difference()` -> `SatSolver::difference_iter()`
    - `SddOr::get_scratch()` -> `SddOr::scratch()`
    - `VarLabel::get_label()` -> `VarLabel::label()`
    - `VarLabel::get_polarity()` -> `VarLabel::polarity()`
    - `VTree::get_all_vars()` -> `VTree::all_vars()`
    - `VTree::vtree_idx` -> `VTree::vtree_index`
    - `VTree::get_varlabel_idx()` -> `VTree::var_index()`
    - `WmcParams::get_weight()` -> `WmcParams::assignment_weight()`
- removing dead code
    - `Bdd::Assignment`
    - `VarOrder::get_var_to_pos_vec()`