### PR TITLE
`BinarySDD`/`SddOr`-related cleanup

### DIFF
--- a/src/builder/sdd/builder.rs
+++ b/src/builder/sdd/builder.rs
@@ -104,7 +104,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
         if bdd.high().is_neg() || self.is_false(bdd.high()) || bdd.high().is_neg_var() {
             let low = bdd.low().neg();
             let high = bdd.high().neg();
-            let neg_bdd = BinarySDD::new(bdd.label(), low, high, bdd.vtree());
+            let neg_bdd = BinarySDD::new(bdd.label(), low, high, bdd.index());
 
             return self.get_or_insert_bdd(neg_bdd).neg();
         }
@@ -146,11 +146,11 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
             SddPtr::BDD(bdd) | SddPtr::ComplBDD(bdd) => {
                 let l = self.and(r.low(), d);
                 let h = self.and(r.high(), d);
-                self.unique_bdd(BinarySDD::new(bdd.label(), l, h, bdd.vtree()))
+                self.unique_bdd(BinarySDD::new(bdd.label(), l, h, bdd.index()))
             }
             SddPtr::Reg(or) | SddPtr::Compl(or) => {
-                let mut v: Vec<SddAnd> = Vec::with_capacity(or.nodes.len());
-                for a in or.nodes.iter() {
+                let mut v: Vec<SddAnd> = Vec::with_capacity(or.iter().len());
+                for a in or.iter() {
                     let root_p = a.prime();
                     let root_s = a.sub();
                     let root_s = if r.is_neg() { root_s.neg() } else { root_s };
@@ -487,7 +487,7 @@ pub trait SddBuilder<'a>: BottomUpBuilder<'a, SddPtr<'a>> {
                 }
                 SddPtr::Reg(or) | SddPtr::Compl(or) => {
                     let mut doc: Doc<BoxDoc> = Doc::from("");
-                    for a in or.nodes.iter() {
+                    for a in or.iter() {
                         let sub = a.sub();
                         let prime = a.prime();
                         let s = if ptr.is_neg() { sub.neg() } else { sub };

--- a/src/repr/sdd/binary_sdd.rs
+++ b/src/repr/sdd/binary_sdd.rs
@@ -18,7 +18,7 @@ use std::{
 #[derive(Debug)]
 pub struct BinarySDD<'a> {
     label: VarLabel,
-    vtree: VTreeIndex,
+    index: VTreeIndex,
     low: SddPtr<'a>,
     high: SddPtr<'a>,
 
@@ -32,21 +32,21 @@ impl<'a> BinarySDD<'a> {
         label: VarLabel,
         low: SddPtr<'a>,
         high: SddPtr<'a>,
-        vtree: VTreeIndex,
+        index: VTreeIndex,
     ) -> BinarySDD<'a> {
         BinarySDD {
             label,
             low,
             high,
-            vtree,
+            index,
             semantic_hash: RefCell::new(None),
             scratch: RefCell::new(None),
         }
     }
 
     #[inline]
-    pub fn vtree(&self) -> VTreeIndex {
-        self.vtree
+    pub fn index(&self) -> VTreeIndex {
+        self.index
     }
 
     #[inline]
@@ -124,7 +124,7 @@ impl<'a> BinarySDD<'a> {
 
 impl<'a> Hash for BinarySDD<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.vtree.hash(state);
+        self.index.hash(state);
         self.label.hash(state);
         self.low.hash(state);
         self.high.hash(state);
@@ -133,7 +133,7 @@ impl<'a> Hash for BinarySDD<'a> {
 
 impl<'a> PartialEq for BinarySDD<'a> {
     fn eq(&self, other: &Self) -> bool {
-        self.vtree == other.vtree
+        self.index == other.index
             && self.low == other.low
             && self.high == other.high
             && self.label == other.label
@@ -154,7 +154,7 @@ impl<'a> Ord for BinarySDD<'a> {
             core::cmp::Ordering::Equal => {}
             ord => return ord,
         }
-        match self.vtree.cmp(&other.vtree) {
+        match self.index.cmp(&other.index) {
             core::cmp::Ordering::Equal => {}
             ord => return ord,
         }
@@ -174,7 +174,7 @@ impl<'a> Clone for BinarySDD<'a> {
     fn clone(&self) -> Self {
         Self {
             label: self.label,
-            vtree: self.vtree,
+            index: self.index,
             low: self.low,
             high: self.high,
             scratch: RefCell::new(None),

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -16,7 +16,7 @@ use std::{
 #[derive(Debug)]
 pub struct SddOr<'a> {
     index: VTreeIndex,
-    pub nodes: Vec<SddAnd<'a>>,
+    nodes: Vec<SddAnd<'a>>,
 
     // scratch
     scratch: RefCell<Option<Box<dyn Any>>>,
@@ -36,6 +36,10 @@ impl<'a> SddOr<'a> {
     #[inline]
     pub fn index(&self) -> VTreeIndex {
         self.index
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, SddAnd<'_>> {
+        self.nodes.iter()
     }
 
     pub fn semantic_hash<const P: u128>(

--- a/src/repr/var_order.rs
+++ b/src/repr/var_order.rs
@@ -6,7 +6,7 @@ use crate::{
     repr::{bdd::BddPtr, var_label::VarLabel},
     util,
 };
-use std::{fmt::Display, slice::Iter};
+use std::fmt::Display;
 
 #[derive(Debug, Clone)]
 pub struct VarOrder {
@@ -137,12 +137,6 @@ impl VarOrder {
                 }
             }
         }
-    }
-
-    /// Produces an iterator of var -> position, where the
-    /// result\[i\] gives the position of variable i in the order
-    pub fn order_iter(&self) -> Iter<usize> {
-        self.var_to_pos.iter()
     }
 
     /// Iterate through the variables in the order in which they appear in the order

--- a/src/serialize/ser_sdd.rs
+++ b/src/serialize/ser_sdd.rs
@@ -89,7 +89,6 @@ impl SDDSerializer {
             }
             SddPtr::Compl(or) | SddPtr::Reg(or) => {
                 let o: Vec<SDDAnd> = or
-                    .nodes
                     .iter()
                     .map(|and| {
                         let p = SDDSerializer::serialize_helper(and.prime(), table, nodes);


### PR DESCRIPTION
- make `SddOr::nodes` private, expose `.iter()` instead
- rename misleading `vtree` to `index`
- remove unused code