### PR TITLE
Fix ITE Cache to be more Rust-like

### DIFF
--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -61,7 +61,7 @@ fn main() {
     println!("num vars: {}", cnf.num_vars());
 
     // TODO: allow user to pick varorder
-    let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+    let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
     let bdd = builder.compile_cnf(&cnf);
 

--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use rsdd::{
     builder::{
         bdd::{BddBuilder, RobddBuilder},
-        cache::all_app::AllTable,
+        cache::all_app::AllIteTable,
     },
     repr::{bdd::BddPtr, cnf::Cnf, var_label::VarLabel, wmc::WmcParams},
     util::semirings::RealSemiring,
@@ -61,7 +61,7 @@ fn main() {
     println!("num vars: {}", cnf.num_vars());
 
     // TODO: allow user to pick varorder
-    let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
+    let builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
     let bdd = builder.compile_cnf(&cnf);
 

--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use rsdd::{
     builder::{
         bdd::{BddBuilder, RobddBuilder},
-        cache::all_app::AllIteTable,
+        cache::AllIteTable,
     },
     repr::{bdd::BddPtr, cnf::Cnf, var_label::VarLabel, wmc::WmcParams},
     util::semirings::RealSemiring,

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -149,7 +149,7 @@ fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
 
 fn compile_bdd(str: String, _args: &Args) -> BenchResult {
     let cnf = Cnf::from_dimacs(&str);
-    let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
+    let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
     let bdd = builder.compile_cnf(&cnf);
 
     if let Some(path) = &_args.dump_bdd {

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use rsdd::builder::bdd::BddBuilder;
 use rsdd::builder::bdd::RobddBuilder;
-use rsdd::builder::cache::lru_app::LruIteTable;
+use rsdd::builder::cache::LruIteTable;
 use rsdd::builder::decision_nnf::DecisionNNFBuilder;
 use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use rsdd::builder::bdd::BddBuilder;
 use rsdd::builder::bdd::RobddBuilder;
-use rsdd::builder::cache::lru_app::BddApplyTable;
+use rsdd::builder::cache::lru_app::LruIteTable;
 use rsdd::builder::decision_nnf::DecisionNNFBuilder;
 use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};
@@ -149,7 +149,7 @@ fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
 
 fn compile_bdd(str: String, _args: &Args) -> BenchResult {
     let cnf = Cnf::from_dimacs(&str);
-    let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
+    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
     let bdd = builder.compile_cnf(&cnf);
 
     if let Some(path) = &_args.dump_bdd {
@@ -169,7 +169,7 @@ fn compile_bdd_dtree(str: String, _args: &Args) -> BenchResult {
     let cnf = Cnf::from_dimacs(&str);
     let order = cnf.min_fill_order();
     let dtree = DTree::from_cnf(&cnf, &order);
-    let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new(order);
+    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new(order);
     let plan = BddPlan::from_dtree(&dtree);
     let bdd = builder.compile_plan(&plan);
 

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -169,8 +169,7 @@ fn compile_bdd_dtree(str: String, _args: &Args) -> BenchResult {
     let cnf = Cnf::from_dimacs(&str);
     let order = cnf.min_fill_order();
     let dtree = DTree::from_cnf(&cnf, &order);
-    let builder =
-        RobddBuilder::<BddApplyTable<BddPtr>>::new(order, BddApplyTable::new(cnf.num_vars()));
+    let builder = RobddBuilder::<BddApplyTable<BddPtr>>::new(order);
     let plan = BddPlan::from_dtree(&dtree);
     let bdd = builder.compile_plan(&plan);
 

--- a/src/builder/bdd/builder.rs
+++ b/src/builder/bdd/builder.rs
@@ -264,7 +264,7 @@ where
     /// # use rsdd::repr::ddnnf::DDNNFPtr;
     /// # use rsdd::builder::cache::all_app::AllTable;
     /// # use rsdd::repr::bdd::BddPtr;
-    /// let mut builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(10);
+    /// let mut builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(10);
     /// let lbl_a = builder.new_label();
     /// let a = builder.var(lbl_a, true);
     /// let a_and_not_a = builder.and(a, a.neg());

--- a/src/builder/bdd/builder.rs
+++ b/src/builder/bdd/builder.rs
@@ -262,7 +262,7 @@ where
     /// # use rsdd::builder::BottomUpBuilder;
     /// # use rsdd::repr::var_label::VarLabel;
     /// # use rsdd::repr::ddnnf::DDNNFPtr;
-    /// # use rsdd::builder::cache::all_app::AllIteTable;
+    /// # use rsdd::builder::cache::AllIteTable;
     /// # use rsdd::repr::bdd::BddPtr;
     /// let mut builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(10);
     /// let lbl_a = builder.new_label();

--- a/src/builder/bdd/builder.rs
+++ b/src/builder/bdd/builder.rs
@@ -262,9 +262,9 @@ where
     /// # use rsdd::builder::BottomUpBuilder;
     /// # use rsdd::repr::var_label::VarLabel;
     /// # use rsdd::repr::ddnnf::DDNNFPtr;
-    /// # use rsdd::builder::cache::all_app::AllTable;
+    /// # use rsdd::builder::cache::all_app::AllIteTable;
     /// # use rsdd::repr::bdd::BddPtr;
-    /// let mut builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(10);
+    /// let mut builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(10);
     /// let lbl_a = builder.new_label();
     /// let a = builder.var(lbl_a, true);
     /// let a_and_not_a = builder.and(a, a.neg());

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -2,7 +2,7 @@ use crate::{
     backing_store::{BackedRobinhoodTable, UniqueTable},
     builder::{
         bdd::{BddBuilder, BddBuilderStats},
-        cache::{all_app::AllTable, ite::Ite, lru_app::BddApplyTable, LruTable},
+        cache::{ite::Ite, LruTable},
         BottomUpBuilder,
     },
     repr::{
@@ -94,17 +94,6 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> BddBuilder<'a> for RobddBuilder<'a, T> {
 }
 
 impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
-    /// Make a BDD manager with a default variable ordering
-    pub fn new_default_order(num_vars: usize) -> RobddBuilder<'a, AllTable<BddPtr<'a>>> {
-        let default_order = VarOrder::linear_order(num_vars);
-        RobddBuilder::new(default_order)
-    }
-
-    pub fn new_default_order_lru(num_vars: usize) -> RobddBuilder<'a, BddApplyTable<BddPtr<'a>>> {
-        let default_order = VarOrder::linear_order(num_vars);
-        RobddBuilder::new(default_order)
-    }
-
     /// Creates a new variable manager with the specified order
     pub fn new(order: VarOrder) -> RobddBuilder<'a, T> {
         RobddBuilder {
@@ -113,6 +102,12 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
             apply_table: RefCell::new(T::new()),
             stats: RefCell::new(BddBuilderStats::new()),
         }
+    }
+
+    /// Make a BDD manager with a default variable ordering
+    pub fn new_with_linear_order(num_vars: usize) -> RobddBuilder<'a, T> {
+        let default_order = VarOrder::linear_order(num_vars);
+        RobddBuilder::new(default_order)
     }
 
     /// Returns the number of variables in the manager
@@ -331,7 +326,7 @@ mod tests {
     // check that (a \/ b) /\ a === a
     #[test]
     fn simple_equality() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let v1 = builder.var(VarLabel::new(0), true);
         let v2 = builder.var(VarLabel::new(1), true);
         let r1 = builder.or(v1, v2);
@@ -346,7 +341,7 @@ mod tests {
 
     #[test]
     fn simple_ite1() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let v1 = builder.var(VarLabel::new(0), true);
         let v2 = builder.var(VarLabel::new(1), true);
         let r1 = builder.or(v1, v2);
@@ -361,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_newvar() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(0);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(0);
         let l1 = builder.new_label();
         let l2 = builder.new_label();
         let v1 = builder.var(l1, true);
@@ -378,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_wmc() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(2);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(2);
         let v1 = builder.var(VarLabel::new(0), true);
         let v2 = builder.var(VarLabel::new(1), true);
         let r1 = builder.or(v1, v2);
@@ -393,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_condition() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let v1 = builder.var(VarLabel::new(0), true);
         let v2 = builder.var(VarLabel::new(1), true);
         let r1 = builder.or(v1, v2);
@@ -403,7 +398,7 @@ mod tests {
 
     #[test]
     fn test_condition_compl() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let v1 = builder.var(VarLabel::new(0), false);
         let v2 = builder.var(VarLabel::new(1), false);
         let r1 = builder.and(v1, v2);
@@ -418,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_exist() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         // 1 /\ 2 /\ 3
         let v1 = builder.var(VarLabel::new(0), true);
         let v2 = builder.var(VarLabel::new(1), true);
@@ -437,7 +432,7 @@ mod tests {
 
     #[test]
     fn test_exist_compl() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         // 1 /\ 2 /\ 3
         let v1 = builder.var(VarLabel::new(0), false);
         let v2 = builder.var(VarLabel::new(1), false);
@@ -457,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_compose() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let v0 = builder.var(VarLabel::new(0), true);
         let v1 = builder.var(VarLabel::new(1), true);
         let v2 = builder.var(VarLabel::new(2), true);
@@ -474,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_compose_2() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(4);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(4);
         let v0 = builder.var(VarLabel::new(0), true);
         let v1 = builder.var(VarLabel::new(1), true);
         let v2 = builder.var(VarLabel::new(2), true);
@@ -493,7 +488,7 @@ mod tests {
 
     #[test]
     fn test_compose_3() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(4);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(4);
         let v0 = builder.var(VarLabel::new(0), true);
         let v1 = builder.var(VarLabel::new(1), true);
         let v2 = builder.var(VarLabel::new(2), true);
@@ -510,7 +505,7 @@ mod tests {
 
     #[test]
     fn test_compose_4() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(20);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(20);
         let v0 = builder.var(VarLabel::new(4), true);
         let v1 = builder.var(VarLabel::new(5), true);
         let v2 = builder.var(VarLabel::new(6), true);
@@ -527,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_new_label() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(0);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(0);
         let vlbl1 = builder.new_label();
         let vlbl2 = builder.new_label();
         let v1 = builder.var(vlbl1, false);
@@ -544,7 +539,7 @@ mod tests {
 
     #[test]
     fn circuit1() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let x = builder.var(VarLabel::new(0), false);
         let y = builder.var(VarLabel::new(1), true);
         let delta = builder.and(x, y);
@@ -564,7 +559,7 @@ mod tests {
 
     #[test]
     fn simple_cond() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(3);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(3);
         let x = builder.var(VarLabel::new(0), true);
         let y = builder.var(VarLabel::new(1), false);
         let z = builder.var(VarLabel::new(2), false);
@@ -585,7 +580,7 @@ mod tests {
 
     #[test]
     fn wmc_test_2() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(4);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(4);
         let x = builder.var(VarLabel::new(0), true);
         let y = builder.var(VarLabel::new(1), true);
         let f1 = builder.var(VarLabel::new(2), true);
@@ -612,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_ite_1() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(16);
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
         let c1 = Cnf::from_string("(1 || 2) && (0 || -2)");
         let c2 = Cnf::from_string("(0 || 1) && (-4 || -7)");
         let cnf1 = builder.compile_cnf(&c1);
@@ -643,7 +638,7 @@ mod tests {
         ";
         let cnf = Cnf::from_dimacs(CNF);
 
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
         let bdd = builder.compile_cnf(&cnf);
 
@@ -674,7 +669,7 @@ mod tests {
         ";
         let cnf = Cnf::from_dimacs(CNF);
 
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
         let bdd = builder.compile_cnf(&cnf);
 
@@ -702,7 +697,7 @@ mod tests {
         ";
         let cnf = Cnf::from_dimacs(CNF);
 
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
         let bdd = builder.compile_cnf(&cnf);
 

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -2,7 +2,7 @@ use crate::{
     backing_store::{BackedRobinhoodTable, UniqueTable},
     builder::{
         bdd::{BddBuilder, BddBuilderStats},
-        cache::{ite::Ite, IteTable},
+        cache::{Ite, IteTable},
         BottomUpBuilder,
     },
     repr::{
@@ -316,7 +316,7 @@ mod tests {
     use crate::builder::BottomUpBuilder;
     use crate::repr::wmc::WmcParams;
     use crate::util::semirings::{FiniteField, RealSemiring};
-    use crate::{builder::cache::all_app::AllIteTable, repr::ddnnf::DDNNFPtr};
+    use crate::{builder::cache::AllIteTable, repr::ddnnf::DDNNFPtr};
 
     use crate::{
         builder::bdd::robdd::RobddBuilder,

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -15,14 +15,14 @@ use crate::{
 };
 use std::cell::RefCell;
 
-pub struct RobddBuilder<'a, T: IteTable<'a, BddPtr<'a>>> {
+pub struct RobddBuilder<'a, T: IteTable<'a, BddPtr<'a>> + Default> {
     compute_table: RefCell<BackedRobinhoodTable<'a, BddNode<'a>>>,
     apply_table: RefCell<T>,
     stats: RefCell<BddBuilderStats>,
     order: RefCell<VarOrder>,
 }
 
-impl<'a, T: IteTable<'a, BddPtr<'a>>> BddBuilder<'a> for RobddBuilder<'a, T> {
+impl<'a, T: IteTable<'a, BddPtr<'a>> + Default> BddBuilder<'a> for RobddBuilder<'a, T> {
     fn less_than(&self, a: VarLabel, b: VarLabel) -> bool {
         self.order.borrow().lt(a, b)
     }
@@ -93,13 +93,13 @@ impl<'a, T: IteTable<'a, BddPtr<'a>>> BddBuilder<'a> for RobddBuilder<'a, T> {
     }
 }
 
-impl<'a, T: IteTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
+impl<'a, T: IteTable<'a, BddPtr<'a>> + Default> RobddBuilder<'a, T> {
     /// Creates a new variable manager with the specified order
     pub fn new(order: VarOrder) -> RobddBuilder<'a, T> {
         RobddBuilder {
             compute_table: RefCell::new(BackedRobinhoodTable::new()),
             order: RefCell::new(order),
-            apply_table: RefCell::new(T::new()),
+            apply_table: RefCell::new(T::default()),
             stats: RefCell::new(BddBuilderStats::new()),
         }
     }

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -97,20 +97,20 @@ impl<'a, T: LruTable<'a, BddPtr<'a>>> RobddBuilder<'a, T> {
     /// Make a BDD manager with a default variable ordering
     pub fn new_default_order(num_vars: usize) -> RobddBuilder<'a, AllTable<BddPtr<'a>>> {
         let default_order = VarOrder::linear_order(num_vars);
-        RobddBuilder::new(default_order, AllTable::new())
+        RobddBuilder::new(default_order)
     }
 
     pub fn new_default_order_lru(num_vars: usize) -> RobddBuilder<'a, BddApplyTable<BddPtr<'a>>> {
         let default_order = VarOrder::linear_order(num_vars);
-        RobddBuilder::new(default_order, BddApplyTable::new(21))
+        RobddBuilder::new(default_order)
     }
 
     /// Creates a new variable manager with the specified order
-    pub fn new(order: VarOrder, table: T) -> RobddBuilder<'a, T> {
+    pub fn new(order: VarOrder) -> RobddBuilder<'a, T> {
         RobddBuilder {
             compute_table: RefCell::new(BackedRobinhoodTable::new()),
             order: RefCell::new(order),
-            apply_table: RefCell::new(table),
+            apply_table: RefCell::new(T::new()),
             stats: RefCell::new(BddBuilderStats::new()),
         }
     }

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -46,10 +46,8 @@ impl<'a, T: DDNNFPtr<'a>> LruTable<'a, T> for AllTable<T> {
             Ite::IteConst(f) => Some(f),
         }
     }
-}
 
-impl<'a, T: DDNNFPtr<'a>> AllTable<T> {
-    pub fn new() -> AllTable<T> {
+    fn new() -> AllTable<T> {
         AllTable {
             table: FxHashMap::default(),
         }

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -1,7 +1,7 @@
 //! Apply cache for BDD operations that stores all ITEs
 
 use crate::{
-    builder::cache::{ite::Ite, IteTable},
+    builder::cache::{Ite, IteTable},
     repr::ddnnf::DDNNFPtr,
 };
 use rustc_hash::FxHashMap;

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -1,19 +1,19 @@
 //! Apply cache for BDD operations that stores all ITEs
 
 use crate::{
-    builder::cache::{ite::Ite, LruTable},
+    builder::cache::{ite::Ite, IteTable},
     repr::ddnnf::DDNNFPtr,
 };
 use rustc_hash::FxHashMap;
 
 /// An Ite structure, assumed to be in standard form.
 /// The top-level data structure that caches applications
-pub struct AllTable<T> {
+pub struct AllIteTable<T> {
     /// a vector of applications, indexed by the top label of the first pointer.
     table: FxHashMap<(T, T, T), T>,
 }
 
-impl<'a, T: DDNNFPtr<'a>> LruTable<'a, T> for AllTable<T> {
+impl<'a, T: DDNNFPtr<'a>> IteTable<'a, T> for AllIteTable<T> {
     fn hash(&self, _ite: &Ite<T>) -> u64 {
         // do nothing; the all-cache uses a hashbrown table that caches all applies
         0
@@ -47,15 +47,15 @@ impl<'a, T: DDNNFPtr<'a>> LruTable<'a, T> for AllTable<T> {
         }
     }
 
-    fn new() -> AllTable<T> {
-        AllTable {
+    fn new() -> AllIteTable<T> {
+        AllIteTable {
             table: FxHashMap::default(),
         }
     }
 }
 
-impl<'a, T: DDNNFPtr<'a>> Default for AllTable<T> {
-    fn default() -> AllTable<T> {
+impl<'a, T: DDNNFPtr<'a>> Default for AllIteTable<T> {
+    fn default() -> AllIteTable<T> {
         Self::new()
     }
 }

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -46,7 +46,9 @@ impl<'a, T: DDNNFPtr<'a>> IteTable<'a, T> for AllIteTable<T> {
             Ite::IteConst(f) => Some(f),
         }
     }
+}
 
+impl<'a, T: DDNNFPtr<'a>> AllIteTable<T> {
     fn new() -> AllIteTable<T> {
         AllIteTable {
             table: FxHashMap::default(),

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -1,6 +1,6 @@
 //! Apply cache for ITEs that uses a dynamically-expanding LRU cache
 use crate::{
-    builder::cache::{ite::Ite, LruTable},
+    builder::cache::{ite::Ite, IteTable},
     repr::ddnnf::DDNNFPtr,
     util::lru::*,
 };
@@ -10,12 +10,12 @@ use std::hash::{Hash, Hasher};
 const INITIAL_CAPACITY: usize = 16; // given as a power of two
 
 /// The top-level data structure that caches applications
-pub struct BddApplyTable<T: Eq + PartialEq + Clone + Hash + std::fmt::Debug> {
+pub struct LruIteTable<T: Eq + PartialEq + Clone + Hash + std::fmt::Debug> {
     /// a vector of applications, indexed by the top label of the first pointer.
     table: Lru<(T, T, T), T>,
 }
 
-impl<'a, T: DDNNFPtr<'a>> LruTable<'a, T> for BddApplyTable<T> {
+impl<'a, T: DDNNFPtr<'a>> IteTable<'a, T> for LruIteTable<T> {
     /// Insert an ite (f, g, h) into the apply table
     fn insert(&mut self, ite: Ite<T>, res: T, hash: u64) {
         match ite {
@@ -56,14 +56,14 @@ impl<'a, T: DDNNFPtr<'a>> LruTable<'a, T> for BddApplyTable<T> {
         }
     }
 
-    fn new() -> BddApplyTable<T> {
-        BddApplyTable {
+    fn new() -> LruIteTable<T> {
+        LruIteTable {
             table: Lru::new(INITIAL_CAPACITY),
         }
     }
 }
 
-impl<'a, T: DDNNFPtr<'a>> Default for BddApplyTable<T> {
+impl<'a, T: DDNNFPtr<'a>> Default for LruIteTable<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -55,12 +55,16 @@ impl<'a, T: DDNNFPtr<'a>> LruTable<'a, T> for BddApplyTable<T> {
             Ite::IteConst(_) => 0, // do not cache base-cases
         }
     }
-}
 
-impl<'a, T: DDNNFPtr<'a>> BddApplyTable<T> {
-    pub fn new(_num_vars: usize) -> BddApplyTable<T> {
+    fn new() -> BddApplyTable<T> {
         BddApplyTable {
             table: Lru::new(INITIAL_CAPACITY),
         }
+    }
+}
+
+impl<'a, T: DDNNFPtr<'a>> Default for BddApplyTable<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -55,7 +55,9 @@ impl<'a, T: DDNNFPtr<'a>> IteTable<'a, T> for LruIteTable<T> {
             Ite::IteConst(_) => 0, // do not cache base-cases
         }
     }
+}
 
+impl<'a, T: DDNNFPtr<'a>> LruIteTable<T> {
     fn new() -> LruIteTable<T> {
         LruIteTable {
             table: Lru::new(INITIAL_CAPACITY),

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -1,6 +1,6 @@
 //! Apply cache for ITEs that uses a dynamically-expanding LRU cache
 use crate::{
-    builder::cache::{ite::Ite, IteTable},
+    builder::cache::{Ite, IteTable},
     repr::ddnnf::DDNNFPtr,
     util::lru::*,
 };

--- a/src/builder/cache/mod.rs
+++ b/src/builder/cache/mod.rs
@@ -6,7 +6,7 @@ pub mod all_app;
 pub mod ite;
 pub mod lru_app;
 
-pub trait LruTable<'a, T: DDNNFPtr<'a>> {
+pub trait IteTable<'a, T: DDNNFPtr<'a>> {
     fn new() -> Self;
     fn hash(&self, ite: &Ite<T>) -> u64;
     fn insert(&mut self, ite: Ite<T>, res: T, hash: u64);

--- a/src/builder/cache/mod.rs
+++ b/src/builder/cache/mod.rs
@@ -1,10 +1,12 @@
 use crate::repr::ddnnf::DDNNFPtr;
 
-use self::ite::Ite;
+mod all_app;
+mod ite;
+mod lru_app;
 
-pub mod all_app;
-pub mod ite;
-pub mod lru_app;
+pub use self::all_app::*;
+pub use self::ite::*;
+pub use self::lru_app::*;
 
 pub trait IteTable<'a, T: DDNNFPtr<'a>> {
     fn hash(&self, ite: &Ite<T>) -> u64;

--- a/src/builder/cache/mod.rs
+++ b/src/builder/cache/mod.rs
@@ -7,6 +7,7 @@ pub mod ite;
 pub mod lru_app;
 
 pub trait LruTable<'a, T: DDNNFPtr<'a>> {
+    fn new() -> Self;
     fn hash(&self, ite: &Ite<T>) -> u64;
     fn insert(&mut self, ite: Ite<T>, res: T, hash: u64);
     fn get(&self, ite: Ite<T>, hash: u64) -> Option<T>;

--- a/src/builder/cache/mod.rs
+++ b/src/builder/cache/mod.rs
@@ -7,7 +7,6 @@ pub mod ite;
 pub mod lru_app;
 
 pub trait IteTable<'a, T: DDNNFPtr<'a>> {
-    fn new() -> Self;
     fn hash(&self, ite: &Ite<T>) -> u64;
     fn insert(&mut self, ite: Ite<T>, res: T, hash: u64);
     fn get(&self, ite: Ite<T>, hash: u64) -> Option<T>;

--- a/src/builder/sdd/builder.rs
+++ b/src/builder/sdd/builder.rs
@@ -2,7 +2,7 @@
 //! with SDDs.
 
 use crate::{
-    builder::{cache::ite::Ite, BottomUpBuilder},
+    builder::{cache::Ite, BottomUpBuilder},
     repr::{
         cnf::Cnf,
         ddnnf::DDNNFPtr,

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -157,7 +157,7 @@ impl<'a> CompressionSddBuilder<'a> {
     pub fn new(vtree: VTree) -> CompressionSddBuilder<'a> {
         let vtree_man = VTreeManager::new(vtree);
         CompressionSddBuilder {
-            ite_cache: RefCell::new(AllIteTable::new()),
+            ite_cache: RefCell::new(AllIteTable::default()),
             app_cache: RefCell::new(HashMap::new()),
             bdd_tbl: RefCell::new(BackedRobinhoodTable::new()),
             sdd_tbl: RefCell::new(BackedRobinhoodTable::new()),

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -1,7 +1,7 @@
 use crate::{
     backing_store::{BackedRobinhoodTable, UniqueTable},
     builder::{
-        cache::{all_app::AllTable, ite::Ite, LruTable},
+        cache::{all_app::AllIteTable, ite::Ite, IteTable},
         sdd::{SddBuilder, SddBuilderStats},
         BottomUpBuilder,
     },
@@ -20,7 +20,7 @@ pub struct CompressionSddBuilder<'a> {
     bdd_tbl: RefCell<BackedRobinhoodTable<'a, BinarySDD<'a>>>,
     sdd_tbl: RefCell<BackedRobinhoodTable<'a, SddOr<'a>>>,
     // caches
-    ite_cache: RefCell<AllTable<SddPtr<'a>>>,
+    ite_cache: RefCell<AllIteTable<SddPtr<'a>>>,
     app_cache: RefCell<HashMap<SddAnd<'a>, SddPtr<'a>>>,
     // stats
     num_recursive_calls: RefCell<usize>,
@@ -157,7 +157,7 @@ impl<'a> CompressionSddBuilder<'a> {
     pub fn new(vtree: VTree) -> CompressionSddBuilder<'a> {
         let vtree_man = VTreeManager::new(vtree);
         CompressionSddBuilder {
-            ite_cache: RefCell::new(AllTable::new()),
+            ite_cache: RefCell::new(AllIteTable::new()),
             app_cache: RefCell::new(HashMap::new()),
             bdd_tbl: RefCell::new(BackedRobinhoodTable::new()),
             sdd_tbl: RefCell::new(BackedRobinhoodTable::new()),

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -1,7 +1,7 @@
 use crate::{
     backing_store::{BackedRobinhoodTable, UniqueTable},
     builder::{
-        cache::{all_app::AllIteTable, ite::Ite, IteTable},
+        cache::{AllIteTable, Ite, IteTable},
         sdd::{SddBuilder, SddBuilderStats},
         BottomUpBuilder,
     },

--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -26,7 +26,7 @@ pub struct SemanticSddBuilder<'a, const P: u128> {
     bdd_tbl: RefCell<BackedRobinhoodTable<'a, BinarySDD<'a>>>,
     sdd_tbl: RefCell<BackedRobinhoodTable<'a, SddOr<'a>>>,
     // caches
-    // ite_cache: RefCell<AllTable<SddPtr<'a>>>,
+    // ite_cache: RefCell<AllIteTable<SddPtr<'a>>>,
     app_cache: RefCell<HashMap<u128, SddPtr<'a>>>,
     // semantic hashing
     map: WmcParams<FiniteField<P>>,
@@ -158,7 +158,7 @@ impl<'a, const P: u128> SemanticSddBuilder<'a, P> {
         SemanticSddBuilder {
             should_compress: false,
             vtree: vtree_man,
-            // ite_cache: RefCell::new(AllTable::new()),
+            // ite_cache: RefCell::new(AllIteTable::new()),
             app_cache: RefCell::new(HashMap::new()),
             bdd_tbl: RefCell::new(BackedRobinhoodTable::new()),
             sdd_tbl: RefCell::new(BackedRobinhoodTable::new()),

--- a/src/builder/sdd/semantic.rs
+++ b/src/builder/sdd/semantic.rs
@@ -1,7 +1,7 @@
 use crate::{
     backing_store::BackedRobinhoodTable,
     builder::{
-        cache::ite::Ite,
+        cache::Ite,
         sdd::{SddBuilder, SddBuilderStats},
     },
     repr::{

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     builder::{
         bdd::{BddBuilder, RobddBuilder},
-        cache::{all_app::AllTable, lru_app::BddApplyTable},
+        cache::all_app::AllTable,
         sdd::{CompressionSddBuilder, SddBuilder},
     },
     constants::primes,
@@ -49,8 +49,7 @@ pub fn vtree(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, Js
 pub fn bdd(cnf_input: String) -> String {
     let cnf = Cnf::from_dimacs(&cnf_input);
 
-    let builder: RobddBuilder<'_, BddApplyTable<BddPtr<'_>>> =
-        RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
+    let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
     let bdd = builder.compile_cnf(&cnf);
 
     let json = BDDSerializer::from_bdd(bdd);

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     builder::{
         bdd::{BddBuilder, RobddBuilder},
-        cache::all_app::AllIteTable,
+        cache::AllIteTable,
         sdd::{CompressionSddBuilder, SddBuilder},
     },
     constants::primes,

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     builder::{
         bdd::{BddBuilder, RobddBuilder},
-        cache::all_app::AllTable,
+        cache::all_app::AllIteTable,
         sdd::{CompressionSddBuilder, SddBuilder},
     },
     constants::primes,
@@ -49,7 +49,7 @@ pub fn vtree(cnf_input: String, vtree_type_input: JsValue) -> Result<JsValue, Js
 pub fn bdd(cnf_input: String) -> String {
     let cnf = Cnf::from_dimacs(&cnf_input);
 
-    let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
+    let builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
     let bdd = builder.compile_cnf(&cnf);
 
     let json = BDDSerializer::from_bdd(bdd);
@@ -64,7 +64,7 @@ pub fn bdd_with_var_order(cnf_input: String, order: &[u64]) -> String {
 
     let var_order = VarOrder::new(order.iter().map(|v| VarLabel::new(*v)).collect());
 
-    let builder = RobddBuilder::<AllTable<BddPtr>>::new(var_order);
+    let builder = RobddBuilder::<AllIteTable<BddPtr>>::new(var_order);
     let bdd = builder.compile_cnf(&cnf);
 
     let json = BDDSerializer::from_bdd(bdd);

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -65,7 +65,7 @@ pub fn bdd_with_var_order(cnf_input: String, order: &[u64]) -> String {
 
     let var_order = VarOrder::new(order.iter().map(|v| VarLabel::new(*v)).collect());
 
-    let builder = RobddBuilder::new(var_order, AllTable::new());
+    let builder = RobddBuilder::<AllTable<BddPtr>>::new(var_order);
     let bdd = builder.compile_cnf(&cnf);
 
     let json = BDDSerializer::from_bdd(bdd);

--- a/tests/network_example.rs
+++ b/tests/network_example.rs
@@ -4,7 +4,7 @@
 // extern crate rsdd;
 // use crate::repr::var_label::VarLabel;
 // use rsdd::builder::bdd_builder::RobddBuilder;
-// use rsdd::builder::cache::all_app::AllTable;
+// use rsdd::builder::cache::all_app::AllIteTable;
 // use rsdd::repr::robdd::BddPtr;
 // use rsdd::repr::ddnnf::DDNNFPtr;
 // use rsdd::repr::wmc::WmcParams;
@@ -17,10 +17,10 @@
 // // For example, network_gen(4) will generate a network with top path edges
 // // st1, t1t2, t2t3, t3t4, t4e.
 // // Output is: BDDPtr to network, associated BDDManager, Vec of edge VarLabels
-// fn network_gen(n: usize) -> (BddPtr, RobddBuilder<AllTable<BddPtr>>, Vec<VarLabel>) {
+// fn network_gen(n: usize) -> (BddPtr, RobddBuilder<AllIteTable<BddPtr>>, Vec<VarLabel>) {
 //     // Initialize BDD
 //     let bdd_size = (2 * n) + 2;
-//     let mut man = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(bdd_size);
+//     let mut man = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(bdd_size);
 
 //     // Initialize variables in the BDD, sort into top or bottom edge
 //     let v: Vec<VarLabel> = (0..bdd_size).map(|x| VarLabel::new(x as u64)).collect();
@@ -51,10 +51,10 @@
 // //         Vec of VarLabels of Decisions, VarLabel of Reward.
 // fn decisions(
 //     n: usize,
-//     mut man: RobddBuilder<AllTable<BddPtr>>,
+//     mut man: RobddBuilder<AllIteTable<BddPtr>>,
 // ) -> (
 //     BddPtr,
-//     RobddBuilder<AllTable<BddPtr>>,
+//     RobddBuilder<AllIteTable<BddPtr>>,
 //     Vec<VarLabel>,
 //     VarLabel,
 // ) {

--- a/tests/network_example.rs
+++ b/tests/network_example.rs
@@ -20,7 +20,7 @@
 // fn network_gen(n: usize) -> (BddPtr, RobddBuilder<AllTable<BddPtr>>, Vec<VarLabel>) {
 //     // Initialize BDD
 //     let bdd_size = (2 * n) + 2;
-//     let mut man = RobddBuilder::<AllTable<BddPtr>>::new_default_order(bdd_size);
+//     let mut man = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(bdd_size);
 
 //     // Initialize variables in the BDD, sort into top or bottom edge
 //     let v: Vec<VarLabel> = (0..bdd_size).map(|x| VarLabel::new(x as u64)).collect();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate rsdd;
 #[macro_use]
 extern crate quickcheck;
 use rsdd::builder::bdd::{BddBuilder, RobddBuilder};
-use rsdd::builder::cache::all_app::AllIteTable;
+use rsdd::builder::cache::AllIteTable;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};
 use rsdd::repr::bdd::BddPtr;
 use rsdd::repr::cnf::Cnf;
@@ -273,8 +273,8 @@ mod test_bdd_builder {
     use rand::Rng;
     use rsdd::builder::bdd::BddBuilder;
     use rsdd::builder::bdd::RobddBuilder;
-    use rsdd::builder::cache::all_app::AllIteTable;
-    use rsdd::builder::cache::lru_app::LruIteTable;
+    use rsdd::builder::cache::AllIteTable;
+    use rsdd::builder::cache::LruIteTable;
     use rsdd::builder::decision_nnf::DecisionNNFBuilder;
     use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
     use rsdd::builder::sdd::SddBuilder;
@@ -672,7 +672,7 @@ mod test_sdd_builder {
     use rand::SeedableRng;
     use rsdd::builder::bdd::BddBuilder;
     use rsdd::builder::bdd::RobddBuilder;
-    use rsdd::builder::cache::all_app::AllIteTable;
+    use rsdd::builder::cache::AllIteTable;
     use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder, SemanticSddBuilder};
     use rsdd::builder::BottomUpBuilder;
     use rsdd::constants::primes;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -207,7 +207,7 @@ fn canonical_forms() -> Vec<(Cnf, Cnf)> {
 #[test]
 fn test_bdd_canonicity() {
     for (cnf1, cnf2) in canonical_forms().into_iter() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf1.num_vars());
+        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf1.num_vars());
         let r1 = builder.compile_cnf(&cnf1);
         let r2 = builder.compile_cnf(&cnf2);
         assert!(
@@ -297,7 +297,7 @@ mod test_bdd_builder {
 
     quickcheck! {
         fn test_cond_and(c: Cnf) -> bool {
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(16);
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
             let cnf = builder.compile_cnf(&c);
             let v1 = VarLabel::new(0);
             let bdd1 = builder.exists(cnf, v1);
@@ -311,7 +311,7 @@ mod test_bdd_builder {
 
     quickcheck! {
         fn test_ite_and(c1: Cnf, c2: Cnf) -> bool {
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(16);
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
             let cnf1 = builder.compile_cnf(&c1);
             let cnf2 = builder.compile_cnf(&c2);
 
@@ -326,7 +326,7 @@ mod test_bdd_builder {
         fn bdd_ite_iff(c1: Cnf, c2: Cnf) -> TestResult {
             if c1.num_vars() == 0 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 12 { return TestResult::discard() }
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(16);
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
             let cnf1 = builder.compile_cnf(&c1);
             let cnf2 = builder.compile_cnf(&c2);
             let iff1 = builder.iff(cnf1, cnf2);
@@ -348,7 +348,7 @@ mod test_bdd_builder {
         fn compile_with_assignments(c1: Cnf) -> TestResult {
             if c1.num_vars() < 3 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 12 { return TestResult::discard() }
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let mut pm = PartialModel::from_litvec(&Vec::new(), c1.num_vars());
             pm.set(VarLabel::new(0), true);
             pm.set(VarLabel::new(1), true);
@@ -368,7 +368,7 @@ mod test_bdd_builder {
             if c1.num_vars() == 0 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 16 { return TestResult::discard() }
 
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight = create_semantic_hash_map::<{primes::U32_SMALL}>(c1.num_vars());
             let cnf1 = builder.compile_cnf(&c1);
             let bddres = cnf1.wmc(builder.order(), &weight);
@@ -380,7 +380,7 @@ mod test_bdd_builder {
     quickcheck! {
         /// test that an SDD and BDD both have the same semantic hash
         fn sdd_semantic_eq_bdd(c1: Cnf, vtree: VTree) -> bool {
-            let bdd_builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
+            let bdd_builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let sdd_builder = super::CompressionSddBuilder::new(vtree);
             let map : WmcParams<rsdd::util::semirings::FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(c1.num_vars());
             let bdd = bdd_builder.compile_cnf(&c1);
@@ -392,7 +392,7 @@ mod test_bdd_builder {
     quickcheck! {
         /// test that an SDD and BDD both have the same semantic hash with min-fill order
         fn sdd_semantic_eq_bdd_dtree(c1: Cnf) -> bool {
-            let bdd_builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
+            let bdd_builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let min_fill_order = c1.min_fill_order();
             let dtree = DTree::from_cnf(&c1, &min_fill_order);
             let vtree = VTree::from_dtree(&dtree).unwrap();
@@ -411,7 +411,7 @@ mod test_bdd_builder {
             if c1.num_vars() == 0 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 16 { return TestResult::discard() }
 
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
             let order = VarOrder::linear_order(c1.num_vars());
@@ -435,8 +435,8 @@ mod test_bdd_builder {
     quickcheck! {
         /// test if the lru cache and the all cache give the same results
         fn bdd_lru(c1: Cnf) -> TestResult {
-            let builder1 = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(16);
-            let builder2 = super::RobddBuilder::<BddApplyTable<BddPtr>>::new_default_order_lru(16);
+            let builder1 = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
+            let builder2 = super::RobddBuilder::<BddApplyTable<BddPtr>>::new_with_linear_order(16);
 
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
@@ -457,7 +457,7 @@ mod test_bdd_builder {
             if c1.num_vars() < 5 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 14 { return TestResult::discard() }
 
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
             let cnf = builder.compile_cnf(&c1);
@@ -541,7 +541,7 @@ mod test_bdd_builder {
             // constrain the size, make BDD
             if !(5..=8).contains(&n) { return TestResult::discard() }
             if c1.clauses().len() > 14 { return TestResult::discard() }
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_default_order(n);
+            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(n);
             let cnf = builder.compile_cnf(&c1);
 
             // randomizing the decisions
@@ -649,7 +649,7 @@ mod test_bdd_builder {
 
     quickcheck! {
         fn smooth_and_unsmooth_bdd_agree(cnf: Cnf) -> bool {
-            let builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+            let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
             let bdd = builder.compile_cnf(&cnf);
 
@@ -762,7 +762,7 @@ mod test_sdd_builder {
            let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
 
 
-            let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+            let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
             let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
             assert_eq!(bdd_res, sdd_res);
@@ -787,7 +787,7 @@ mod test_sdd_builder {
             let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
 
 
-            let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_default_order(cnf.num_vars());
+            let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
             let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
             assert_eq!(bdd_res, sdd_res);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate rsdd;
 #[macro_use]
 extern crate quickcheck;
 use rsdd::builder::bdd::{BddBuilder, RobddBuilder};
-use rsdd::builder::cache::all_app::AllTable;
+use rsdd::builder::cache::all_app::AllIteTable;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};
 use rsdd::repr::bdd::BddPtr;
 use rsdd::repr::cnf::Cnf;
@@ -207,7 +207,7 @@ fn canonical_forms() -> Vec<(Cnf, Cnf)> {
 #[test]
 fn test_bdd_canonicity() {
     for (cnf1, cnf2) in canonical_forms().into_iter() {
-        let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf1.num_vars());
+        let builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf1.num_vars());
         let r1 = builder.compile_cnf(&cnf1);
         let r2 = builder.compile_cnf(&cnf2);
         assert!(
@@ -273,8 +273,8 @@ mod test_bdd_builder {
     use rand::Rng;
     use rsdd::builder::bdd::BddBuilder;
     use rsdd::builder::bdd::RobddBuilder;
-    use rsdd::builder::cache::all_app::AllTable;
-    use rsdd::builder::cache::lru_app::BddApplyTable;
+    use rsdd::builder::cache::all_app::AllIteTable;
+    use rsdd::builder::cache::lru_app::LruIteTable;
     use rsdd::builder::decision_nnf::DecisionNNFBuilder;
     use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
     use rsdd::builder::sdd::SddBuilder;
@@ -297,7 +297,7 @@ mod test_bdd_builder {
 
     quickcheck! {
         fn test_cond_and(c: Cnf) -> bool {
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(16);
             let cnf = builder.compile_cnf(&c);
             let v1 = VarLabel::new(0);
             let bdd1 = builder.exists(cnf, v1);
@@ -311,7 +311,7 @@ mod test_bdd_builder {
 
     quickcheck! {
         fn test_ite_and(c1: Cnf, c2: Cnf) -> bool {
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(16);
             let cnf1 = builder.compile_cnf(&c1);
             let cnf2 = builder.compile_cnf(&c2);
 
@@ -326,7 +326,7 @@ mod test_bdd_builder {
         fn bdd_ite_iff(c1: Cnf, c2: Cnf) -> TestResult {
             if c1.num_vars() == 0 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 12 { return TestResult::discard() }
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(16);
             let cnf1 = builder.compile_cnf(&c1);
             let cnf2 = builder.compile_cnf(&c2);
             let iff1 = builder.iff(cnf1, cnf2);
@@ -348,7 +348,7 @@ mod test_bdd_builder {
         fn compile_with_assignments(c1: Cnf) -> TestResult {
             if c1.num_vars() < 3 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 12 { return TestResult::discard() }
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let mut pm = PartialModel::from_litvec(&Vec::new(), c1.num_vars());
             pm.set(VarLabel::new(0), true);
             pm.set(VarLabel::new(1), true);
@@ -368,7 +368,7 @@ mod test_bdd_builder {
             if c1.num_vars() == 0 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 16 { return TestResult::discard() }
 
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight = create_semantic_hash_map::<{primes::U32_SMALL}>(c1.num_vars());
             let cnf1 = builder.compile_cnf(&c1);
             let bddres = cnf1.wmc(builder.order(), &weight);
@@ -380,7 +380,7 @@ mod test_bdd_builder {
     quickcheck! {
         /// test that an SDD and BDD both have the same semantic hash
         fn sdd_semantic_eq_bdd(c1: Cnf, vtree: VTree) -> bool {
-            let bdd_builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
+            let bdd_builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let sdd_builder = super::CompressionSddBuilder::new(vtree);
             let map : WmcParams<rsdd::util::semirings::FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(c1.num_vars());
             let bdd = bdd_builder.compile_cnf(&c1);
@@ -392,7 +392,7 @@ mod test_bdd_builder {
     quickcheck! {
         /// test that an SDD and BDD both have the same semantic hash with min-fill order
         fn sdd_semantic_eq_bdd_dtree(c1: Cnf) -> bool {
-            let bdd_builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
+            let bdd_builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let min_fill_order = c1.min_fill_order();
             let dtree = DTree::from_cnf(&c1, &min_fill_order);
             let vtree = VTree::from_dtree(&dtree).unwrap();
@@ -411,7 +411,7 @@ mod test_bdd_builder {
             if c1.num_vars() == 0 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 16 { return TestResult::discard() }
 
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
             let order = VarOrder::linear_order(c1.num_vars());
@@ -435,8 +435,8 @@ mod test_bdd_builder {
     quickcheck! {
         /// test if the lru cache and the all cache give the same results
         fn bdd_lru(c1: Cnf) -> TestResult {
-            let builder1 = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(16);
-            let builder2 = super::RobddBuilder::<BddApplyTable<BddPtr>>::new_with_linear_order(16);
+            let builder1 = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(16);
+            let builder2 = super::RobddBuilder::<LruIteTable<BddPtr>>::new_with_linear_order(16);
 
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
@@ -457,7 +457,7 @@ mod test_bdd_builder {
             if c1.num_vars() < 5 || c1.num_vars() > 8 { return TestResult::discard() }
             if c1.clauses().len() > 14 { return TestResult::discard() }
 
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(c1.num_vars());
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight_map : HashMap<VarLabel, (RealSemiring, RealSemiring)> = HashMap::from_iter(
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
             let cnf = builder.compile_cnf(&c1);
@@ -541,7 +541,7 @@ mod test_bdd_builder {
             // constrain the size, make BDD
             if !(5..=8).contains(&n) { return TestResult::discard() }
             if c1.clauses().len() > 14 { return TestResult::discard() }
-            let builder = super::RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(n);
+            let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(n);
             let cnf = builder.compile_cnf(&c1);
 
             // randomizing the decisions
@@ -649,7 +649,7 @@ mod test_bdd_builder {
 
     quickcheck! {
         fn smooth_and_unsmooth_bdd_agree(cnf: Cnf) -> bool {
-            let builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
+            let builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
 
             let bdd = builder.compile_cnf(&cnf);
 
@@ -672,7 +672,7 @@ mod test_sdd_builder {
     use rand::SeedableRng;
     use rsdd::builder::bdd::BddBuilder;
     use rsdd::builder::bdd::RobddBuilder;
-    use rsdd::builder::cache::all_app::AllTable;
+    use rsdd::builder::cache::all_app::AllIteTable;
     use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder, SemanticSddBuilder};
     use rsdd::builder::BottomUpBuilder;
     use rsdd::constants::primes;
@@ -762,7 +762,7 @@ mod test_sdd_builder {
            let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
 
 
-            let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
+            let bdd_builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
             let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
             assert_eq!(bdd_res, sdd_res);
@@ -787,7 +787,7 @@ mod test_sdd_builder {
             let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
 
 
-            let bdd_builder = RobddBuilder::<AllTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
+            let bdd_builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
             let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
             assert_eq!(bdd_res, sdd_res);


### PR DESCRIPTION
This PR:

- renames things to be more consistent:
    - the table trait is now called `IteTable`. Not all the implements are Lru (so I'm not sure if that made sense), and `Ite` is bound to the type
    - the `BddApplyTable` is now called the `LruIteTable`, since the previous name didn't indicate that it was Lru or operated on `Ite`
    - the `AllTable` is not called `AllIteTable` for consistency
- flattens the `builder::cache` hierarchy, so now it is `builder::cache::IteTable`, etc. (instead of `builder::cache::ite_table::IteTable`)
- renames `new_default_order` to `new_with_linear_order` to be more clear
- removes the concrete type constructors for `RobddBuilder`, since they can imply a different type than the actual parametrized type (ex, an `RobddBuilder` over `AllIteTable` could return an `RobddBuilder` over `LruIteTable`, which doesn't make sense)
- automatically instantiates the `IteTable` for the `RobddBuilder` using the `Default` trait instead of having it in the constructor, since that's what we do in all callsites anyways

I would have loved to then alias the `IteTable`s over a `BddPtr` as some sort of `BddIteTable`, but unfortunately, [trait aliases are unstable](https://doc.rust-lang.org/beta/unstable-book/language-features/trait-alias.html).