### PR TITLE
Move shared `compile_*` to `BottomUpBuilder`

### DIFF
--- a/bin/bottomup_cnf_to_bdd.rs
+++ b/bin/bottomup_cnf_to_bdd.rs
@@ -2,10 +2,7 @@ use std::{fs, time::Instant};
 
 use clap::Parser;
 use rsdd::{
-    builder::{
-        bdd::{BddBuilder, RobddBuilder},
-        cache::LruIteTable,
-    },
+    builder::{bdd::RobddBuilder, cache::LruIteTable, BottomUpBuilder},
     plan::BottomUpPlan,
     repr::{bdd::BddPtr, cnf::Cnf, dtree::DTree},
     serialize::BDDSerializer,

--- a/examples/marginal_map_experiment.rs
+++ b/examples/marginal_map_experiment.rs
@@ -3,10 +3,7 @@ use std::{collections::HashMap, fs};
 use clap::Parser;
 use rand::Rng;
 use rsdd::{
-    builder::{
-        bdd::{BddBuilder, RobddBuilder},
-        cache::AllIteTable,
-    },
+    builder::{bdd::RobddBuilder, cache::AllIteTable, BottomUpBuilder},
     repr::{bdd::BddPtr, cnf::Cnf, var_label::VarLabel, wmc::WmcParams},
     util::semirings::RealSemiring,
 };

--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
-use rsdd::builder::bdd::BddBuilder;
 use rsdd::builder::bdd::RobddBuilder;
 use rsdd::builder::cache::LruIteTable;
 use rsdd::builder::decision_nnf::DecisionNNFBuilder;
 use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};
+use rsdd::builder::BottomUpBuilder;
 use rsdd::plan::BottomUpPlan;
 use rsdd::repr::bdd::BddPtr;
 use rsdd::repr::cnf::Cnf;

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -318,7 +318,6 @@ mod tests {
     use std::borrow::Borrow;
     use std::collections::HashMap;
 
-    use crate::builder::bdd::builder::BddBuilder;
     use crate::builder::BottomUpBuilder;
     use crate::repr::wmc::WmcParams;
     use crate::util::semirings::{FiniteField, RealSemiring};

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,8 +1,9 @@
 use crate::{
     builder::{
-        bdd::{BddBuilder, RobddBuilder},
+        bdd::RobddBuilder,
         cache::AllIteTable,
         sdd::{CompressionSddBuilder, SddBuilder},
+        BottomUpBuilder,
     },
     constants::primes,
     repr::{

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,9 +4,10 @@
 extern crate rsdd;
 #[macro_use]
 extern crate quickcheck;
-use rsdd::builder::bdd::{BddBuilder, RobddBuilder};
+use rsdd::builder::bdd::RobddBuilder;
 use rsdd::builder::cache::AllIteTable;
 use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder};
+use rsdd::builder::BottomUpBuilder;
 use rsdd::repr::bdd::BddPtr;
 use rsdd::repr::cnf::Cnf;
 use rsdd::repr::var_label::VarLabel;
@@ -670,7 +671,6 @@ mod test_sdd_builder {
     use rand::rngs::SmallRng;
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
-    use rsdd::builder::bdd::BddBuilder;
     use rsdd::builder::bdd::RobddBuilder;
     use rsdd::builder::cache::AllIteTable;
     use rsdd::builder::sdd::{CompressionSddBuilder, SddBuilder, SemanticSddBuilder};


### PR DESCRIPTION
Now, the SDD builder gets quite a bit of behaviour for free!

(also, renames `from_boolexpr` to `from_logical_expr` for consistency)