### PR TITLE
Adds Logical S-expression serialization, sketches out `bottomup_formula_to_bdd`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,11 @@ name = "bottomup_cnf_to_bdd"
 path = "bin/bottomup_cnf_to_bdd.rs"
 required-features = ["cli"]
 
+[[bin]]
+name = "bottomup_formula_to_bdd"
+path = "bin/bottomup_formula_to_bdd.rs"
+required-features = ["cli"]
+
 [[example]]
 name = "one_shot_benchmark"
 path = "examples/one_shot_benchmark.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ primal = "0.3.0"
 pretty = "0.3.3"
 quickcheck = "1.0.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_sexpr = { version = "0.1.0" }
 rustc-hash = "1.1.0"
 bit-set = "0.5.3"
 segment-tree = "2.0.0"

--- a/bin/bottomup_formula_to_bdd.rs
+++ b/bin/bottomup_formula_to_bdd.rs
@@ -3,9 +3,15 @@ use std::{fs, time::Instant};
 use clap::Parser;
 use rsdd::{
     builder::{bdd::RobddBuilder, cache::LruIteTable, BottomUpBuilder},
-    repr::{bdd::BddPtr, logical_expr::LogicalExpr, var_order::VarOrder},
+    repr::{bdd::BddPtr, logical_expr::LogicalExpr, var_label::VarLabel, var_order::VarOrder},
     serialize::{BDDSerializer, LogicalSExpr},
 };
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Config {
+    order: Vec<String>,
+}
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -15,8 +21,13 @@ struct Args {
     file: String,
 
     /// variable order for BDD.
+    /// options: `linear`, `manual` (requires config in `-c`)
     #[clap(long, value_parser, default_value_t = String::from("linear"))]
     ordering: String,
+
+    /// (optional) config file for variable ordering
+    #[clap(short, long, value_parser)]
+    config: Option<String>,
 
     /// show verbose output (including timing information, cache profiling, etc.)
     #[clap(short, long, value_parser)]
@@ -28,6 +39,13 @@ fn main() {
 
     let file = fs::read_to_string(args.file).unwrap();
 
+    let config: Option<Config> = if let Some(path_to_config) = args.config {
+        let config = fs::read_to_string(path_to_config).unwrap();
+        Some(serde_json::from_str::<Config>(&config).unwrap())
+    } else {
+        None
+    };
+
     let sexpr = serde_sexpr::from_str::<LogicalSExpr>(&file).unwrap();
     let expr = LogicalExpr::from_sexpr(&sexpr);
 
@@ -35,15 +53,30 @@ fn main() {
 
     let order = match args.ordering.as_str() {
         "linear" => VarOrder::linear_order(sexpr.unique_variables().len()),
+        "manual" => {
+            let mapping = sexpr.variable_mapping();
+            match config {
+                Some(c) => VarOrder::new(
+                    c.order
+                        .iter()
+                        .map(|var| VarLabel::new(*mapping.get(var).unwrap() as u64))
+                        .collect(),
+                ),
+                None => panic!("error; `manual` ordering requires config, passed in with -c"),
+            }
+        }
         _ => todo!(),
     };
 
-    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new(order);
+    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new(order.clone());
     let bdd = builder.compile_logical_expr(&expr);
 
     let elapsed = start.elapsed();
 
     if args.verbose {
+        eprintln!("=== METADATA ===");
+        eprintln!("variable mapping: {:?}", sexpr.variable_mapping());
+        eprintln!("variable ordering: {}", order);
         eprintln!("=== STATS ===");
 
         let stats = builder.stats();

--- a/bin/bottomup_formula_to_bdd.rs
+++ b/bin/bottomup_formula_to_bdd.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct Config {
-    order: Vec<String>,
+    order: Option<Vec<String>>,
 }
 
 #[derive(Parser, Debug)]
@@ -55,15 +55,14 @@ fn main() {
         "linear" => VarOrder::linear_order(sexpr.unique_variables().len()),
         "manual" => {
             let mapping = sexpr.variable_mapping();
-            match config {
-                Some(c) => VarOrder::new(
-                    c.order
-                        .iter()
-                        .map(|var| VarLabel::new(*mapping.get(var).unwrap() as u64))
-                        .collect(),
-                ),
-                None => panic!("error; `manual` ordering requires config, passed in with -c"),
-            }
+            let config = config.unwrap();
+            let order = config.order.unwrap();
+            VarOrder::new(
+                order
+                    .iter()
+                    .map(|var| VarLabel::new(*mapping.get(var).unwrap() as u64))
+                    .collect(),
+            )
         }
         _ => todo!(),
     };

--- a/bin/bottomup_formula_to_bdd.rs
+++ b/bin/bottomup_formula_to_bdd.rs
@@ -1,0 +1,57 @@
+use std::{fs, time::Instant};
+
+use clap::Parser;
+use rsdd::{
+    builder::{bdd::RobddBuilder, cache::LruIteTable, BottomUpBuilder},
+    repr::{bdd::BddPtr, logical_expr::LogicalExpr, var_order::VarOrder},
+    serialize::{BDDSerializer, LogicalSExpr},
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// input logical expression in s expression form
+    #[clap(short, long, value_parser)]
+    file: String,
+
+    /// variable order for BDD.
+    #[clap(long, value_parser, default_value_t = String::from("linear"))]
+    ordering: String,
+
+    /// show verbose output (including timing information, cache profiling, etc.)
+    #[clap(short, long, value_parser)]
+    verbose: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let file = fs::read_to_string(args.file).unwrap();
+
+    let sexpr = serde_sexpr::from_str::<LogicalSExpr>(&file).unwrap();
+    let expr = LogicalExpr::from_sexpr(&sexpr);
+
+    let start = Instant::now();
+
+    let order = match args.ordering.as_str() {
+        "linear" => VarOrder::linear_order(sexpr.unique_variables().len()),
+        _ => todo!(),
+    };
+
+    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new(order);
+    let bdd = builder.compile_logical_expr(&expr);
+
+    let elapsed = start.elapsed();
+
+    if args.verbose {
+        eprintln!("=== STATS ===");
+
+        let stats = builder.stats();
+        eprintln!("compilation time: {:.4}s", elapsed.as_secs_f64());
+        eprintln!("recursive calls: {}", stats.num_recursive_calls);
+    }
+
+    let serialized = BDDSerializer::from_bdd(bdd);
+
+    println!("{}", serde_json::to_string(&serialized).unwrap());
+}

--- a/bloop.sexp
+++ b/bloop.sexp
@@ -1,0 +1,1 @@
+(And (Or (Var X) (Var Y)) (Or (Not (Var X)) (Not (Var Y))))

--- a/bloop.sexp
+++ b/bloop.sexp
@@ -1,1 +1,0 @@
-(And (Or (Var X) (Var Y)) (Or (Not (Var X)) (Not (Var Y))))

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -1,9 +1,11 @@
 //! contains representations of core datastructures that can be serialized
 
 mod ser_bdd;
+mod ser_logical_expr;
 mod ser_sdd;
 mod ser_vtree;
 
 pub use self::ser_bdd::*;
+pub use self::ser_logical_expr::*;
 pub use self::ser_sdd::*;
 pub use self::ser_vtree::*;

--- a/src/serialize/ser_logical_expr.rs
+++ b/src/serialize/ser_logical_expr.rs
@@ -1,0 +1,147 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub enum LogicalSExpr {
+    True,
+    False,
+    Var(String),
+    Not(Box<LogicalSExpr>),
+    Or(Box<LogicalSExpr>, Box<LogicalSExpr>),
+    And(Box<LogicalSExpr>, Box<LogicalSExpr>),
+}
+
+impl LogicalSExpr {
+    /// ```
+    /// use rsdd::serialize::LogicalSExpr;
+    ///
+    /// let expr =
+    /// serde_sexpr::from_str::<LogicalSExpr>("(Or (Var X) (Or (Not (Var X)) (Var Y)))").unwrap();
+    /// let vars = expr.unique_variables();
+
+    /// assert!(vars.len() == 2);
+    /// assert!(vars.contains(&String::from("X")));
+    /// assert!(vars.contains(&String::from("Y")));
+    /// ```
+    pub fn unique_variables(&self) -> HashSet<&String> {
+        match self {
+            LogicalSExpr::True | LogicalSExpr::False => HashSet::new(),
+            LogicalSExpr::Var(s) => HashSet::from([s]),
+            LogicalSExpr::Not(l) => l.unique_variables(),
+            LogicalSExpr::Or(a, b) | LogicalSExpr::And(a, b) => a
+                .unique_variables()
+                .union(&b.unique_variables())
+                .cloned()
+                .collect::<HashSet<&String>>(),
+        }
+    }
+
+    /// ```
+    /// use rsdd::serialize::LogicalSExpr;
+    ///
+    /// let expr =
+    /// serde_sexpr::from_str::<LogicalSExpr>("(Or (Var X) (Or (Not (Var X)) (Var Y)))").unwrap();
+    /// let vars = expr.unique_variables();
+
+    /// assert_eq!(*mapping.get(&String::from("X")).unwrap(), 0);
+    /// assert_eq!(*mapping.get(&String::from("Y")).unwrap(), 1);
+    /// assert_eq!(mapping.get(&String::from("Z")), None);
+    /// ```
+    pub fn variable_mapping(&self) -> HashMap<&String, usize> {
+        let mut v: Vec<_> = self.unique_variables().into_iter().collect();
+        v.sort();
+        HashMap::from_iter(v.into_iter().enumerate().map(|(index, val)| (val, index)))
+    }
+}
+
+#[test]
+fn logical_expression_deserialization_base_cases() {
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("True").unwrap(),
+        LogicalSExpr::True
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("False").unwrap(),
+        LogicalSExpr::False
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Var x)").unwrap(),
+        LogicalSExpr::Var(String::from("x"))
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Var X)").unwrap(),
+        LogicalSExpr::Var(String::from("X"))
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Var 1)").unwrap(),
+        LogicalSExpr::Var(String::from("1"))
+    );
+}
+
+#[test]
+fn logical_expression_deserialization_boxed() {
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Not True)").unwrap(),
+        LogicalSExpr::Not(Box::new(LogicalSExpr::True))
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Not False)").unwrap(),
+        LogicalSExpr::Not(Box::new(LogicalSExpr::False))
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Not (Var X))").unwrap(),
+        LogicalSExpr::Not(Box::new(LogicalSExpr::Var(String::from("X"))))
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(Or (Var X) (Var Y))").unwrap(),
+        LogicalSExpr::Or(
+            Box::new(LogicalSExpr::Var(String::from("X"))),
+            Box::new(LogicalSExpr::Var(String::from("Y")))
+        )
+    );
+
+    assert_eq!(
+        serde_sexpr::from_str::<LogicalSExpr>("(And (Var X) (Var Y))").unwrap(),
+        LogicalSExpr::And(
+            Box::new(LogicalSExpr::Var(String::from("X"))),
+            Box::new(LogicalSExpr::Var(String::from("Y")))
+        )
+    );
+}
+
+#[test]
+fn logical_expression_unique_variables_trivial() {
+    let expr = serde_sexpr::from_str::<LogicalSExpr>("(Var X)").unwrap();
+    let vars = expr.unique_variables();
+
+    assert!(vars.len() == 1);
+    assert!(vars.contains(&String::from("X")));
+}
+
+#[test]
+fn logical_expression_unique_variables_handles_duplicates_and_nesting() {
+    let expr =
+        serde_sexpr::from_str::<LogicalSExpr>("(Or (Var X) (Or (Not (Var X)) (Var Y)))").unwrap();
+    let vars = expr.unique_variables();
+
+    assert!(vars.len() == 2);
+    assert!(vars.contains(&String::from("X")));
+    assert!(vars.contains(&String::from("Y")));
+}
+
+#[test]
+fn logical_expression_variable_mapping_is_lexicographic() {
+    let expr =
+        serde_sexpr::from_str::<LogicalSExpr>("(Or (Var X) (Or (Not (Var X)) (Var Y)))").unwrap();
+    let mapping = expr.variable_mapping();
+
+    assert_eq!(*mapping.get(&String::from("X")).unwrap(), 0);
+    assert_eq!(*mapping.get(&String::from("Y")).unwrap(), 1);
+    assert_eq!(mapping.get(&String::from("Z")), None);
+}

--- a/src/serialize/ser_logical_expr.rs
+++ b/src/serialize/ser_logical_expr.rs
@@ -41,7 +41,8 @@ impl LogicalSExpr {
     /// let expr =
     /// serde_sexpr::from_str::<LogicalSExpr>("(Or (Var X) (Or (Not (Var X)) (Var Y)))").unwrap();
     /// let vars = expr.unique_variables();
-
+    /// let mapping = expr.variable_mapping();
+    ///
     /// assert_eq!(*mapping.get(&String::from("X")).unwrap(), 0);
     /// assert_eq!(*mapping.get(&String::from("Y")).unwrap(), 1);
     /// assert_eq!(mapping.get(&String::from("Z")), None);


### PR DESCRIPTION
Part of #155.

Usage:

```
$ cat bloop.sexp 
(And (Or (Var X) (Var Y)) (Or (Not (Var X)) (Not (Var Y))))
$ cargo run --bin bottomup_formula_to_bdd --features="cli" -- -f bloop.sexp
{"nodes":[{"topvar":1,"low":"False","high":"True"},{"topvar":0,"low":{"Ptr":{"index":0,"compl":true}},"high":{"Ptr":{"index":0,"compl":false}}}],"roots":[{"Ptr":{"index":1,"compl":true}}]}
```

Or, for a manual ordering,

```
$ cat bloop.sexp 
(And (Or (Var X) (Var Y)) (Or (Not (Var X)) (Not (Var Y))))
$ cat bloop.json
{ "order": ["Y", "X"] }
$ cargo run --bin bottomup_formula_to_bdd --features="cli" -- -f bloop.sexp -v --ordering manual -c bloop.json
=== METADATA ===
variable mapping: {"X": 0, "Y": 1}
variable ordering: [1, 0]
=== STATS ===
compilation time: 0.0033s
recursive calls: 9
{"nodes":[{"topvar":0,"low":"False","high":"True"},{"topvar":1,"low":{"Ptr":{"index":0,"compl":true}},"high":{"Ptr":{"index":0,"compl":false}}}],"roots":[{"Ptr":{"index":1,"compl":true}}]}
```