### PR TITLE
Fix `Cnf::new()` to borrow top-level slice instead of vector

### DIFF
--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -263,7 +263,7 @@ impl Iterator for AssignmentIter {
 }
 
 impl Cnf {
-    pub fn new(clauses: Vec<Vec<Literal>>) -> Cnf {
+    pub fn new(clauses: &[Vec<Literal>]) -> Cnf {
         let clauses: Vec<Vec<Literal>> = clauses
             .iter()
             .filter(|clause| !clause.is_empty())
@@ -320,7 +320,7 @@ impl Cnf {
             }
             clause_vec.push(lit_vec);
         }
-        Cnf::new(clause_vec)
+        Cnf::new(&clause_vec)
     }
 
     /// Parses a CNF string into a CNF
@@ -354,7 +354,7 @@ impl Cnf {
             }
             clause_vec.push(c);
         }
-        Cnf::new(clause_vec)
+        Cnf::new(&clause_vec)
     }
 
     pub fn rand_cnf(rng: &mut ThreadRng, num_vars: usize, num_clauses: usize) -> Cnf {
@@ -380,7 +380,7 @@ impl Cnf {
                 clause_vec.push(vec![var]);
             }
         }
-        Cnf::new(clause_vec)
+        Cnf::new(&clause_vec)
     }
 
     pub fn num_vars(&self) -> usize {
@@ -580,7 +580,7 @@ impl Cnf {
                 }
             })
             .collect();
-        Cnf::new(new_cnf)
+        Cnf::new(&new_cnf)
     }
 
     pub fn interaction_graph(&self) -> UnGraph<VarLabel, ()> {
@@ -680,7 +680,7 @@ impl Arbitrary for Cnf {
             }
             clauses.push(clause);
         }
-        Cnf::new(clauses)
+        Cnf::new(&clauses)
     }
 }
 
@@ -721,7 +721,7 @@ fn test_cnf_wmc() {
         Literal::new(VarLabel::new(0), true),
         Literal::new(VarLabel::new(1), false),
     ]];
-    let cnf = Cnf::new(v);
+    let cnf = Cnf::new(&v);
     let weights: std::collections::HashMap<
         VarLabel,
         (

--- a/src/repr/unit_prop.rs
+++ b/src/repr/unit_prop.rs
@@ -497,7 +497,7 @@ fn test_unit_propagate_1() {
         ],
     ];
 
-    let cnf = Cnf::new(v);
+    let cnf = Cnf::new(&v);
     match UnitPropagate::new(cnf) {
         None => panic!("test failed - no partial model generated"),
         Some((_, assgn)) => {
@@ -521,7 +521,7 @@ fn test_unit_propagate_2() {
         ],
     ];
 
-    let cnf = Cnf::new(v);
+    let cnf = Cnf::new(&v);
     match UnitPropagate::new(cnf) {
         None => panic!("test failed - no partial model generated"),
         Some((_, assgn)) => {
@@ -550,7 +550,7 @@ fn test_unit_propagate_3() {
         ],
     ];
 
-    let cnf = Cnf::new(v);
+    let cnf = Cnf::new(&v);
     match UnitPropagate::new(cnf) {
         None => panic!("test failed - no partial model generated"),
         Some((_, assgn)) => {
@@ -579,7 +579,7 @@ fn test_unit_propagate_3() {
 //         ],
 //     ];
 
-//     let cnf = Cnf::new(v);
+//     let cnf = Cnf::new(&v);
 //     let up = UnitPropagate::new(&cnf).unwrap();
 //     let assgn = up.get_assgn().get_vec();
 //     assert_eq!(assgn[0], Some(false));
@@ -596,7 +596,7 @@ fn test_unit_propagate_3() {
 //         ],
 //     ];
 
-//     let cnf = Cnf::new(v);
+//     let cnf = Cnf::new(&v);
 //     let mut up = UnitPropagate::new(&cnf).unwrap();
 //     let v1 = up.decide(Literal::new(VarLabel::new(0), false));
 //     assert!(v1);
@@ -611,7 +611,7 @@ fn test_unit_propagate_3() {
 // fn test_unit_propagate_5() {
 //     let v = vec![vec![Literal::new(VarLabel::new(1), true), Literal::new(VarLabel::new(3), true)],
 //                  vec![Literal::new(VarLabel::new(3), false), Literal::new(VarLabel::new(2), true), Literal::new(VarLabel::new(4), true)]];
-//     let cnf = Cnf::new(v);
+//     let cnf = Cnf::new(&v);
 //     let mut up = UnitPropagate::new(&cnf).unwrap();
 //     let v1 = up.decide(Literal::new(VarLabel::new(3), true));
 //     assert!(v1);

--- a/src/util/hypergraph.rs
+++ b/src/util/hypergraph.rs
@@ -275,7 +275,7 @@ mod test {
             ],
             vec![Literal::new(VarLabel::new(5), true)],
         ];
-        let cnf = Cnf::new(v);
+        let cnf = Cnf::new(&v);
         let ig = cnf.interaction_graph();
         println!("{:?}", Dot::with_config(&ig, &[Config::EdgeNoLabel]));
         let _nodes = ig

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -751,7 +751,7 @@ mod test_sdd_builder {
         /// test that the same CNF compiled by both an SDD and BDD have the same weighted model count
         /// with an even_split ordering
         fn sdd_wmc_eq_even_split(clauses: Vec<Vec<Literal>>) -> TestResult {
-            let cnf = Cnf::new(clauses);
+            let cnf = Cnf::new(&clauses);
             if cnf.num_vars() < 8 || cnf.num_vars() > 16 { return TestResult::discard() }
             if cnf.clauses().len() > 16 { return TestResult::discard() }
 
@@ -774,7 +774,7 @@ mod test_sdd_builder {
         /// test that the same CNF compiled by both an SDD and BDD have the same weighted model count
         /// with a dtree ordering
         fn sdd_wmc_eq(clauses: Vec<Vec<Literal>>) -> TestResult {
-            let cnf = Cnf::new(clauses);
+            let cnf = Cnf::new(&clauses);
             if cnf.num_vars() < 8 || cnf.num_vars() > 16 { return TestResult::discard() }
             if cnf.clauses().len() > 16 { return TestResult::discard() }
 


### PR DESCRIPTION
Cherry-picking this change over from #163, to make it easier to review (and to revert this if necessary).