### PR TITLE
Fix `VarOrder` constructor taking ownership, remove duplicate `linear_order`

### DIFF
--- a/bin/bottomup_formula_to_bdd.rs
+++ b/bin/bottomup_formula_to_bdd.rs
@@ -58,10 +58,10 @@ fn main() {
             let config = config.unwrap();
             let order = config.order.unwrap();
             VarOrder::new(
-                order
+                &order
                     .iter()
                     .map(|var| VarLabel::new(*mapping.get(var).unwrap() as u64))
-                    .collect(),
+                    .collect::<Vec<_>>(),
             )
         }
         _ => todo!(),

--- a/examples/semantic_top_down_experiment.rs
+++ b/examples/semantic_top_down_experiment.rs
@@ -122,7 +122,7 @@ impl Iterator for RandomVarOrders {
 
         order.shuffle(&mut thread_rng());
 
-        Some(VarOrder::new(order))
+        Some(VarOrder::new(&order))
     }
 }
 

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -491,10 +491,7 @@ impl Cnf {
     }
 
     pub fn linear_order(&self) -> VarOrder {
-        let v = (0..(self.num_vars))
-            .map(|x| VarLabel::new(x as u64))
-            .collect();
-        VarOrder::new(v)
+        VarOrder::linear_order(self.num_vars)
     }
 
     /// heuristically generate a variable ordering which minimizes the average
@@ -551,7 +548,7 @@ impl Cnf {
             .into_iter()
             .map(|v| VarLabel::new(v as u64))
             .collect();
-        VarOrder::new(final_order)
+        VarOrder::new(&final_order)
     }
 
     /// Updates the CNF to a new CNF that results from conditioning on the supplied literal
@@ -620,7 +617,7 @@ impl Cnf {
         // assert that ord contains each variable exactly once.
         debug_assert!((0..(self.num_vars())).all(|v| ord.contains(&VarLabel::new_usize(v))));
         debug_assert!(ord.len() == self.num_vars);
-        VarOrder::new(ord)
+        VarOrder::new(&ord)
     }
 
     pub fn to_dimacs(&self) -> String {

--- a/src/repr/var_order.rs
+++ b/src/repr/var_order.rs
@@ -18,7 +18,7 @@ pub struct VarOrder {
 impl VarOrder {
     /// Creates a new variable order (elements that occur first in the vector
     /// occur first in the order)
-    pub fn new(order: Vec<VarLabel>) -> VarOrder {
+    pub fn new(order: &[VarLabel]) -> VarOrder {
         let mut v = vec![0; order.len()];
         let mut pos_to_var = Vec::new();
         for i in 0..order.len() {
@@ -31,18 +31,15 @@ impl VarOrder {
         }
     }
 
-    /// Generate a linear variable ordering of size `num_var_to_pos`
+    /// Generate a linear variable ordering of size `num_vars`
     /// ```
     /// # use rsdd::repr::VarOrder;
     /// let o = VarOrder::linear_order(10);
     /// assert_eq!(o.num_vars(), 10);
     /// ```
-    pub fn linear_order(num_var_to_pos: usize) -> VarOrder {
-        let mut v = Vec::new();
-        for i in 0..num_var_to_pos {
-            v.push(VarLabel::new(i as u64))
-        }
-        VarOrder::new(v)
+    pub fn linear_order(num_vars: usize) -> VarOrder {
+        let v: Vec<VarLabel> = (0..num_vars).map(|i| VarLabel::new(i as u64)).collect();
+        VarOrder::new(&v)
     }
 
     /// Gives the number of variables in the order

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -60,7 +60,7 @@ pub fn bdd(cnf_input: String) -> String {
 pub fn bdd_with_var_order(cnf_input: String, order: &[u64]) -> String {
     let cnf = Cnf::from_dimacs(&cnf_input);
 
-    let var_order = VarOrder::new(order.iter().map(|v| VarLabel::new(*v)).collect());
+    let var_order = VarOrder::new(&order.iter().map(|v| VarLabel::new(*v)).collect::<Vec<_>>());
 
     let builder = RobddBuilder::<AllIteTable<BddPtr>>::new(var_order);
     let bdd = builder.compile_cnf(&cnf);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1109,7 +1109,7 @@ mod test_dnnf_builder {
 
             CnfAndOrdering {
                 cnf,
-                order: VarOrder::new(order),
+                order: VarOrder::new(&order),
             }
         }
     }


### PR DESCRIPTION
Not sure why there are two different `linear_order` constructors (that reimplement the same logic); they seem accidental. Also have minorly renamed the argument to be clearer.