### PR TITLE
Remove `Order` from `fold`, `unsmoothed_wmc`, `semantic_hash`

### DIFF
--- a/bin/weighted_model_count.rs
+++ b/bin/weighted_model_count.rs
@@ -140,7 +140,7 @@ fn single_wmc(
     verbose: bool,
     silent: bool,
 ) {
-    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new(order.clone());
+    let builder = RobddBuilder::<LruIteTable<BddPtr>>::new(order);
 
     let unweighted_params: WmcParams<FiniteField<{ primes::U64_LARGEST }>> =
         WmcParams::new(HashMap::from_iter(
@@ -154,7 +154,7 @@ fn single_wmc(
 
     let bdd = builder.smooth(bdd, num_vars);
 
-    let res = bdd.unsmoothed_wmc(&order, &params);
+    let res = bdd.unsmoothed_wmc(&params);
 
     let elapsed = start.elapsed();
 
@@ -163,7 +163,7 @@ fn single_wmc(
             "unweighted model count: {}\nweighted model count: {}",
             builder
                 .smooth(bdd, num_vars)
-                .unsmoothed_wmc(&order, &unweighted_params),
+                .unsmoothed_wmc(&unweighted_params),
             res
         );
     }
@@ -208,8 +208,8 @@ fn partial_wmcs(
         let conditioned = builder.condition_model(bdd, model);
         let smoothed = builder.smooth(conditioned, num_vars - num_conditioned);
 
-        let mc = smoothed.unsmoothed_wmc(order, &unweighted_params).value();
-        let wmc = smoothed.unsmoothed_wmc(order, params);
+        let mc = smoothed.unsmoothed_wmc(&unweighted_params).value();
+        let wmc = smoothed.unsmoothed_wmc(params);
 
         let res = PartialWmcResult {
             partial_model: serialize_partial_model(model, inverse_mapping),

--- a/examples/semantic_top_down_experiment.rs
+++ b/examples/semantic_top_down_experiment.rs
@@ -29,7 +29,7 @@ struct Args {
     random_order: bool,
 }
 
-fn diff_by_wmc(num_vars: usize, order: &VarOrder, std_dnnf: BddPtr, sem_dnnf: BddPtr) -> f64 {
+fn diff_by_wmc(num_vars: usize, std_dnnf: BddPtr, sem_dnnf: BddPtr) -> f64 {
     let weight_map: HashMap<VarLabel, (RealSemiring, RealSemiring)> =
         HashMap::from_iter((0..num_vars).map(|x| {
             (
@@ -39,8 +39,8 @@ fn diff_by_wmc(num_vars: usize, order: &VarOrder, std_dnnf: BddPtr, sem_dnnf: Bd
         }));
     let params = WmcParams::new(weight_map);
 
-    let std_wmc = std_dnnf.unsmoothed_wmc(order, &params);
-    let sem_wmc = sem_dnnf.unsmoothed_wmc(order, &params);
+    let std_wmc = std_dnnf.unsmoothed_wmc(&params);
+    let sem_wmc = sem_dnnf.unsmoothed_wmc(&params);
 
     f64::abs(std_wmc.0 - sem_wmc.0)
 }
@@ -58,7 +58,7 @@ fn compare_sem_and_std(cnf: &Cnf, order: &VarOrder) -> (usize, usize) {
     let sem_dnnf = sem_builder.compile_cnf_topdown(cnf);
     let sem_time = start.elapsed().as_secs_f64();
 
-    if diff_by_wmc(cnf.num_vars(), order, std_dnnf, sem_dnnf) > 0.0001 {
+    if diff_by_wmc(cnf.num_vars(), std_dnnf, sem_dnnf) > 0.0001 {
         println!(
             "error on input {}\n std bdd: {}\nsem bdd: {}",
             cnf,

--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -308,8 +308,6 @@ impl<'a, T: IteTable<'a, BddPtr<'a>> + Default> RobddBuilder<'a, T> {
 
 #[cfg(test)]
 mod tests {
-
-    use std::borrow::Borrow;
     use std::collections::HashMap;
 
     use crate::builder::BottomUpBuilder;
@@ -381,7 +379,7 @@ mod tests {
             (VarLabel::new(1), (RealSemiring(0.1), RealSemiring(0.9))),
         ]);
         let params = WmcParams::new(weights);
-        let wmc = r1.unsmoothed_wmc(builder.order().borrow(), &params);
+        let wmc = r1.unsmoothed_wmc(&params);
         assert!((wmc.0 - (1.0 - 0.2 * 0.1)).abs() < 0.000001);
     }
 
@@ -598,10 +596,7 @@ mod tests {
         let obs = builder.or(x, y);
         let and1 = builder.and(iff1, iff2);
         let f = builder.and(and1, obs);
-        assert_eq!(
-            f.unsmoothed_wmc(builder.order().borrow(), &wmc).0,
-            0.2 * 0.3 + 0.2 * 0.7 + 0.8 * 0.3
-        );
+        assert_eq!(f.unsmoothed_wmc(&wmc).0, 0.2 * 0.3 + 0.2 * 0.7 + 0.8 * 0.3);
     }
 
     #[test]
@@ -649,9 +644,9 @@ mod tests {
             (VarLabel::new(2), (FiniteField::new(1), FiniteField::new(1))),
         ]));
 
-        let unsmoothed_model_count = bdd.unsmoothed_wmc(builder.order(), &weights);
+        let unsmoothed_model_count = bdd.unsmoothed_wmc(&weights);
 
-        let smoothed_model_count = smoothed.unsmoothed_wmc(builder.order(), &weights);
+        let smoothed_model_count = smoothed.unsmoothed_wmc(&weights);
 
         assert_eq!(unsmoothed_model_count.value(), 3);
         assert_eq!(smoothed_model_count.value(), 7);
@@ -674,13 +669,11 @@ mod tests {
 
         let smoothed = builder.smooth(bdd, cnf.num_vars());
 
-        let weighted_model_count = smoothed.unsmoothed_wmc(
-            builder.order(),
-            &WmcParams::<RealSemiring>::new(HashMap::from_iter([
+        let weighted_model_count =
+            smoothed.unsmoothed_wmc(&WmcParams::<RealSemiring>::new(HashMap::from_iter([
                 (VarLabel::new(0), (RealSemiring(0.4), RealSemiring(0.6))),
                 (VarLabel::new(1), (RealSemiring(0.3), RealSemiring(0.7))),
-            ])),
-        );
+            ])));
 
         assert_eq!(weighted_model_count.0, 0.54);
     }
@@ -702,17 +695,16 @@ mod tests {
 
         let smoothed = builder.smooth(bdd, cnf.num_vars());
 
-        let model_count = smoothed.unsmoothed_wmc(
-            builder.order(),
-            &WmcParams::<FiniteField<1000001>>::new(HashMap::from_iter([
+        let model_count = smoothed.unsmoothed_wmc(&WmcParams::<FiniteField<1000001>>::new(
+            HashMap::from_iter([
                 (VarLabel::new(0), (FiniteField::new(1), FiniteField::new(1))),
                 (VarLabel::new(1), (FiniteField::new(1), FiniteField::new(1))),
                 (VarLabel::new(2), (FiniteField::new(1), FiniteField::new(1))),
                 (VarLabel::new(3), (FiniteField::new(1), FiniteField::new(1))),
                 (VarLabel::new(4), (FiniteField::new(1), FiniteField::new(1))),
                 (VarLabel::new(5), (FiniteField::new(1), FiniteField::new(1))),
-            ])),
-        );
+            ]),
+        ));
 
         // TODO: this WMC test is broken. not sure why :(
         // let weighted_model_count = smoothed.unsmoothed_wmc(

--- a/src/builder/decision_nnf/semantic.rs
+++ b/src/builder/decision_nnf/semantic.rs
@@ -49,7 +49,7 @@ impl<'a, const P: u128> DecisionNNFBuilder<'a> for SemanticDecisionNNFBuilder<'a
         let mut seen_hashes = HashSet::new();
         let map = create_semantic_hash_map::<P>(self.order.num_vars());
         for bdd in self.compute_table.borrow().iter() {
-            let h = BddPtr::Reg(bdd).semantic_hash(&self.order, &map);
+            let h = BddPtr::Reg(bdd).semantic_hash(&map);
             if seen_hashes.contains(&(h.value())) {
                 num_collisions += 1;
             } else {
@@ -124,13 +124,12 @@ mod tests {
 
         let linear_order = VarOrder::linear_order(cnf.num_vars());
 
-        let builder =
-            SemanticDecisionNNFBuilder::<{ primes::U32_SMALL }>::new(linear_order.clone());
+        let builder = SemanticDecisionNNFBuilder::<{ primes::U32_SMALL }>::new(linear_order);
         let dnnf = builder.compile_cnf_topdown(&cnf);
 
-        assert!(dnnf.evaluate(&linear_order, &[true, true]));
-        assert!(dnnf.evaluate(&linear_order, &[false, true]));
-        assert!(dnnf.evaluate(&linear_order, &[true, false]));
-        assert!(!dnnf.evaluate(&linear_order, &[false, false]));
+        assert!(dnnf.evaluate(&[true, true]));
+        assert!(dnnf.evaluate(&[false, true]));
+        assert!(dnnf.evaluate(&[true, false]));
+        assert!(!dnnf.evaluate(&[false, false]));
     }
 }

--- a/src/builder/decision_nnf/standard.rs
+++ b/src/builder/decision_nnf/standard.rs
@@ -35,7 +35,7 @@ impl<'a> DecisionNNFBuilder<'a> for StandardDecisionNNFBuilder<'a> {
         let mut seen_hashes = HashSet::new();
         let map = create_semantic_hash_map::<{ primes::U32_SMALL }>(self.order.num_vars());
         for bdd in self.compute_table.borrow().iter() {
-            let h = BddPtr::Reg(bdd).semantic_hash(&self.order, &map);
+            let h = BddPtr::Reg(bdd).semantic_hash(&map);
             if seen_hashes.contains(&(h.value())) {
                 num_collisions += 1;
             } else {
@@ -82,12 +82,12 @@ mod tests {
 
         let linear_order = VarOrder::linear_order(cnf.num_vars());
 
-        let builder = StandardDecisionNNFBuilder::new(linear_order.clone());
+        let builder = StandardDecisionNNFBuilder::new(linear_order);
         let dnnf = builder.compile_cnf_topdown(&cnf);
 
-        assert!(dnnf.evaluate(&linear_order, &[true, true]));
-        assert!(dnnf.evaluate(&linear_order, &[false, true]));
-        assert!(dnnf.evaluate(&linear_order, &[true, false]));
-        assert!(!dnnf.evaluate(&linear_order, &[false, false]));
+        assert!(dnnf.evaluate(&[true, true]));
+        assert!(dnnf.evaluate(&[false, true]));
+        assert!(dnnf.evaluate(&[true, false]));
+        assert!(!dnnf.evaluate(&[false, false]));
     }
 }

--- a/src/builder/sdd/compression.rs
+++ b/src/builder/sdd/compression.rs
@@ -463,7 +463,7 @@ fn sdd_wmc1() {
     let x_fx = builder.iff(x, fx);
     let y_fy = builder.iff(y, fy);
     let ptr = builder.and(x_fx, y_fy);
-    let wmc_res: RealSemiring = ptr.unsmoothed_wmc(builder.vtree_manager(), &wmc_map);
+    let wmc_res: RealSemiring = ptr.unsmoothed_wmc(&wmc_map);
     let expected = RealSemiring(1.0);
     let diff = (wmc_res - expected).0.abs();
     println!("sdd: {}", builder.print_sdd(ptr));

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -892,8 +892,6 @@ impl<'a> BddPtr<'a> {
 type DDNNFCache<T> = (Option<T>, Option<T>);
 
 impl<'a> DDNNFPtr<'a> for BddPtr<'a> {
-    type Order = VarOrder;
-
     fn true_ptr() -> BddPtr<'a> {
         PtrTrue
     }

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -926,7 +926,7 @@ impl<'a> DDNNFPtr<'a> for BddPtr<'a> {
         }
     }
 
-    fn fold<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(&self, _o: &VarOrder, f: F) -> T
+    fn fold<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(&self, f: F) -> T
     where
         T: 'static,
     {

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -63,20 +63,19 @@ pub trait DDNNFPtr<'a>: Clone + Debug + PartialEq + Eq + Hash + Copy {
     type Order;
 
     /// performs a memoized bottom-up pass with aggregating function `f` calls
-    fn fold<T: Semiring, F: Fn(DDNNF<T>) -> T>(&self, o: &Self::Order, f: F) -> T
+    fn fold<T: Semiring, F: Fn(DDNNF<T>) -> T>(&self, f: F) -> T
     where
         T: 'static;
 
     /// Unsmoothed weighted-model count
     fn unsmoothed_wmc<T: Semiring + std::ops::Add<Output = T> + std::ops::Mul<Output = T>>(
         &self,
-        o: &Self::Order,
         params: &WmcParams<T>,
     ) -> T
     where
         T: 'static,
     {
-        self.fold(o, |ddnnf| {
+        self.fold(|ddnnf| {
             use DDNNF::*;
             match ddnnf {
                 Or(l, r, _) => l + r,
@@ -95,28 +94,21 @@ pub trait DDNNFPtr<'a>: Clone + Debug + PartialEq + Eq + Hash + Copy {
         })
     }
 
-    fn evaluate(&self, o: &Self::Order, instantations: &[bool]) -> bool {
-        self.unsmoothed_wmc(
-            o,
-            &WmcParams::new(HashMap::from_iter(instantations.iter().enumerate().map(
-                |(index, polarity)| {
-                    (
-                        VarLabel::new(index as u64),
-                        (BooleanSemiring(!polarity), BooleanSemiring(*polarity)),
-                    )
-                },
-            ))),
-        )
+    fn evaluate(&self, instantations: &[bool]) -> bool {
+        self.unsmoothed_wmc(&WmcParams::new(HashMap::from_iter(
+            instantations.iter().enumerate().map(|(index, polarity)| {
+                (
+                    VarLabel::new(index as u64),
+                    (BooleanSemiring(!polarity), BooleanSemiring(*polarity)),
+                )
+            }),
+        )))
         .0
     }
 
     /// compute the semantic hash for this pointer
-    fn semantic_hash<const P: u128>(
-        &self,
-        order: &Self::Order,
-        map: &WmcParams<FiniteField<P>>,
-    ) -> FiniteField<P> {
-        self.unsmoothed_wmc(order, map)
+    fn semantic_hash<const P: u128>(&self, map: &WmcParams<FiniteField<P>>) -> FiniteField<P> {
+        self.unsmoothed_wmc(map)
     }
 
     /// Negate the pointer

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -56,12 +56,6 @@ pub enum DDNNF<T> {
 }
 
 pub trait DDNNFPtr<'a>: Clone + Debug + PartialEq + Eq + Hash + Copy {
-    /// A generic Ordering type
-    /// For BDDs, this is a VarOrder
-    /// For SDDs, this is a VTree
-    /// For decisionDNNF, this is a DTree
-    type Order;
-
     /// performs a memoized bottom-up pass with aggregating function `f` calls
     fn fold<T: Semiring, F: Fn(DDNNF<T>) -> T>(&self, f: F) -> T
     where

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -272,7 +272,6 @@ impl<'a> DDNNFPtr<'a> for SddPtr<'a> {
 
     fn fold<T: 'static + Clone + Copy + std::fmt::Debug, F: Fn(super::ddnnf::DDNNF<T>) -> T>(
         &self,
-        _v: &VTreeManager,
         f: F,
     ) -> T {
         debug_assert!(self.is_scratch_cleared());

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -268,8 +268,6 @@ impl<'a> SddPtr<'a> {
 type DDNNFCache<T> = (Option<T>, Option<T>);
 
 impl<'a> DDNNFPtr<'a> for SddPtr<'a> {
-    type Order = VTreeManager;
-
     fn fold<T: 'static + Clone + Copy + std::fmt::Debug, F: Fn(super::ddnnf::DDNNF<T>) -> T>(
         &self,
         f: F,

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -107,7 +107,7 @@ pub fn demo_model_count_sdd(cnf_input: String) -> Result<JsValue, JsValue> {
         )
     }
 
-    let model_count = sdd.unsmoothed_wmc(builder.vtree_manager(), &params);
+    let model_count = sdd.unsmoothed_wmc(&params);
 
     let res = SddModelCountResult {
         model_count: model_count.value(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -278,7 +278,6 @@ mod test_bdd_builder {
     use rsdd::builder::cache::LruIteTable;
     use rsdd::builder::decision_nnf::DecisionNNFBuilder;
     use rsdd::builder::decision_nnf::StandardDecisionNNFBuilder;
-    use rsdd::builder::sdd::SddBuilder;
     use rsdd::builder::BottomUpBuilder;
     use rsdd::constants::primes;
     use rsdd::repr::BddPtr;
@@ -372,7 +371,7 @@ mod test_bdd_builder {
             let builder = super::RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(c1.num_vars());
             let weight = create_semantic_hash_map::<{primes::U32_SMALL}>(c1.num_vars());
             let cnf1 = builder.compile_cnf(&c1);
-            let bddres = cnf1.unsmoothed_wmc(builder.order(), &weight);
+            let bddres = cnf1.unsmoothed_wmc(&weight);
             let cnfres = c1.wmc(&weight);
             TestResult::from_bool(bddres == cnfres)
         }
@@ -386,7 +385,7 @@ mod test_bdd_builder {
             let map : WmcParams<rsdd::util::semirings::FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(c1.num_vars());
             let bdd = bdd_builder.compile_cnf(&c1);
             let sdd = sdd_builder.compile_cnf(&c1);
-            bdd.semantic_hash(bdd_builder.order(), &map) == sdd.semantic_hash(sdd_builder.vtree_manager(), &map)
+            bdd.semantic_hash( &map) == sdd.semantic_hash(&map)
         }
     }
 
@@ -402,7 +401,7 @@ mod test_bdd_builder {
             let map : WmcParams<rsdd::util::semirings::FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(c1.num_vars());
             let bdd = bdd_builder.compile_cnf(&c1);
             let sdd = sdd_builder.compile_cnf(&c1);
-            bdd.semantic_hash(bdd_builder.order(), &map) == sdd.semantic_hash(sdd_builder.vtree_manager(), &map)
+            bdd.semantic_hash( &map) == sdd.semantic_hash(&map)
         }
     }
 
@@ -422,8 +421,8 @@ mod test_bdd_builder {
             let dnnf = builder2.compile_cnf_topdown(&c1);
 
             let bddwmc = super::repr::WmcParams::new(weight_map);
-            let bddres = cnf1.unsmoothed_wmc(builder.order(),  &bddwmc);
-            let dnnfres = dnnf.unsmoothed_wmc(builder.order(), &bddwmc);
+            let bddres = cnf1.unsmoothed_wmc( &bddwmc);
+            let dnnfres = dnnf.unsmoothed_wmc(&bddwmc);
             let eps = f64::abs(bddres.0 - dnnfres.0) < 0.0001;
             if !eps {
               println!("error on input {}: bddres {}, cnfres {}\n topdown bdd: {}\nbottom-up bdd: {}",
@@ -445,8 +444,8 @@ mod test_bdd_builder {
             let bddwmc = super::repr::WmcParams::new(weight_map);
             let cnf1 = builder1.compile_cnf(&c1);
             let cnf2 = builder2.compile_cnf(&c1);
-            let wmc1 = cnf1.unsmoothed_wmc(builder1.order(), &bddwmc);
-            let wmc2 = cnf2.unsmoothed_wmc(builder2.order(), &bddwmc);
+            let wmc1 = cnf1.unsmoothed_wmc(&bddwmc);
+            let wmc2 = cnf2.unsmoothed_wmc( &bddwmc);
             TestResult::from_bool(f64::abs(wmc1.0 - wmc2.0) < 0.00001)
         }
     }
@@ -484,7 +483,7 @@ mod test_bdd_builder {
                 let mut conj = builder.and(x, y);
                 conj = builder.and(conj, z);
                 conj = builder.and(conj, cnf);
-                let poss_max = conj.unsmoothed_wmc(builder.order(), &wmc);
+                let poss_max = conj.unsmoothed_wmc(&wmc);
                 if poss_max.0 > max {
                     max = poss_max.0;
                     max_assgn.set(VarLabel::new(0), *v1);
@@ -514,7 +513,7 @@ mod test_bdd_builder {
             let mut conj = builder.and(v0, v1);
             conj = builder.and(conj, v2);
             conj = builder.and(conj, cnf);
-            let poss_max = conj.unsmoothed_wmc(builder.order(), &wmc);
+            let poss_max = conj.unsmoothed_wmc(&wmc);
             if f64::abs(poss_max.0 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -524,7 +523,7 @@ mod test_bdd_builder {
             let mut conj2 = builder.and(w0, w1);
             conj2 = builder.and(conj2, w2);
             builder.and(conj2, cnf);
-            let poss_max2 = conj.unsmoothed_wmc(builder.order(), &wmc);
+            let poss_max2 = conj.unsmoothed_wmc(&wmc);
             if f64::abs(poss_max2.0 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -594,7 +593,7 @@ mod test_bdd_builder {
                 let mut conj = builder.and(x, y);
                 conj = builder.and(conj, z);
                 conj = builder.and(conj, cnf);
-                let poss_max = conj.unsmoothed_wmc(builder.order(), &wmc);
+                let poss_max = conj.unsmoothed_wmc(&wmc);
                 if poss_max.1 > max {
                     max = poss_max.1;
                     max_assgn.set(decisions[0], *v1);
@@ -629,7 +628,7 @@ mod test_bdd_builder {
             let mut conj = builder.and(v0, v1);
             conj = builder.and(conj, v2);
             conj = builder.and(conj, cnf);
-            let poss_max = conj.unsmoothed_wmc(builder.order(), &wmc);
+            let poss_max = conj.unsmoothed_wmc(&wmc);
             if f64::abs(poss_max.1 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -639,7 +638,7 @@ mod test_bdd_builder {
             let mut conj2 = builder.and(w0, w1);
             conj2 = builder.and(conj2, w2);
             builder.and(conj2, cnf);
-            let poss_max2 = conj.unsmoothed_wmc(builder.order(), &wmc);
+            let poss_max2 = conj.unsmoothed_wmc(&wmc);
             if f64::abs(poss_max2.1 - max) > 0.0001 {
                 pm_check = false;
             }
@@ -660,7 +659,7 @@ mod test_bdd_builder {
             // they are with the property that pos_weight + neg_weight = 1
             let map = create_semantic_hash_map::<{primes::U32_SMALL}>(cnf.num_vars());
 
-            bdd.semantic_hash(builder.order(), &map) == smoothed.semantic_hash(builder.order(), &map)
+            bdd.semantic_hash( &map) == smoothed.semantic_hash( &map)
         }
     }
 }
@@ -759,12 +758,12 @@ mod test_sdd_builder {
            let order : Vec<VarLabel> = (0..cnf.num_vars()).map(|x| VarLabel::new(x as u64)).collect();
            let builder = super::CompressionSddBuilder::new(VTree::even_split(&order, 3));
            let cnf_sdd = builder.compile_cnf(&cnf);
-           let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
+           let sdd_res = cnf_sdd.semantic_hash(&weight_map);
 
 
             let bdd_builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
-            let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
+            let bdd_res = cnf_bdd.semantic_hash( &weight_map);
             assert_eq!(bdd_res, sdd_res);
             TestResult::passed()
         }
@@ -784,12 +783,12 @@ mod test_sdd_builder {
             let weight_map = create_semantic_hash_map::<{primes::U32_SMALL}>(cnf.num_vars());
             let builder = super::CompressionSddBuilder::new(vtree);
             let cnf_sdd = builder.compile_cnf(&cnf);
-            let sdd_res = cnf_sdd.semantic_hash(builder.vtree_manager(), &weight_map);
+            let sdd_res = cnf_sdd.semantic_hash(&weight_map);
 
 
             let bdd_builder = RobddBuilder::<AllIteTable<BddPtr>>::new_with_linear_order(cnf.num_vars());
             let cnf_bdd = bdd_builder.compile_cnf(&cnf);
-            let bdd_res = cnf_bdd.semantic_hash(bdd_builder.order(), &weight_map);
+            let bdd_res = cnf_bdd.semantic_hash( &weight_map);
             assert_eq!(bdd_res, sdd_res);
             TestResult::passed()
         }
@@ -872,8 +871,8 @@ mod test_sdd_builder {
 
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>> = create_semantic_hash_map(builder1.num_vars());
 
-            let h1 = c1.semantic_hash(builder1.vtree_manager(), &map);
-            let h2 = c2.semantic_hash(builder2.vtree_manager(), &map);
+            let h1 = c1.semantic_hash(&map);
+            let h2 = c2.semantic_hash(&map);
 
             h1 == h2
         }
@@ -899,8 +898,8 @@ mod test_sdd_builder {
 
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>> = create_semantic_hash_map(compr_builder.num_vars());
 
-            let compr_h = compr_cnf.semantic_hash(compr_builder.vtree_manager(), &map);
-            let uncompr_h = uncompr_cnf.semantic_hash(uncompr_builder.vtree_manager(), &map);
+            let compr_h = compr_cnf.semantic_hash(&map);
+            let uncompr_h = uncompr_cnf.semantic_hash(&map);
 
             if compr_h != uncompr_h {
                 println!("not equal! hashes: compr: {compr_h}, uncompr: {uncompr_h}");
@@ -985,7 +984,7 @@ mod test_sdd_builder {
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(builder.num_vars());
             let mut seen_hashes : HashMap<u128, SddPtr> = HashMap::new();
             for sdd in builder.node_iter() {
-                let hash = sdd.semantic_hash(builder.vtree_manager(), &map);
+                let hash = sdd.semantic_hash(&map);
                 if seen_hashes.contains_key(&hash.value()) {
                     let c = seen_hashes.get(&hash.value()).unwrap();
                     println!("cnf: {}", c1);
@@ -1011,7 +1010,7 @@ mod test_sdd_builder {
             let map : WmcParams<FiniteField<{primes::U32_SMALL}>>= create_semantic_hash_map(builder.num_vars());
             let mut seen_hashes : HashMap<u128, SddPtr> = HashMap::new();
             for sdd in builder.node_iter() {
-                let hash = sdd.semantic_hash(builder.vtree_manager(), &map);
+                let hash = sdd.semantic_hash(&map);
 
                 // see the hash itself
                 if seen_hashes.contains_key(&hash.value()) {
@@ -1063,8 +1062,8 @@ mod test_sdd_builder {
             let sdd = builder.compile_cnf(&c1);
             let compl = sdd.neg();
 
-            let sdd_hash = sdd.semantic_hash(builder.vtree_manager(), &map);
-            let compl_hash = compl.semantic_hash(builder.vtree_manager(), &map);
+            let sdd_hash = sdd.semantic_hash(&map);
+            let compl_hash = compl.semantic_hash(&map);
 
             let sum = (sdd_hash + compl_hash).value();
 
@@ -1146,7 +1145,7 @@ mod test_dnnf_builder {
             let std_builder = StandardDecisionNNFBuilder::new(linear_order.clone());
             let std_dnnf = std_builder.compile_cnf_topdown(&cnf);
 
-            let sem_builder = SemanticDecisionNNFBuilder::<{primes::U64_LARGEST}>::new(linear_order.clone());
+            let sem_builder = SemanticDecisionNNFBuilder::<{primes::U64_LARGEST}>::new(linear_order);
             let sem_dnnf = sem_builder.compile_cnf_topdown(&cnf);
 
 
@@ -1154,8 +1153,8 @@ mod test_dnnf_builder {
                 (0..16).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
             let params = WmcParams::new(weight_map);
 
-            let std_wmc = std_dnnf.unsmoothed_wmc(&linear_order, &params);
-            let sem_wmc = sem_dnnf.unsmoothed_wmc(&linear_order, &params);
+            let std_wmc = std_dnnf.unsmoothed_wmc(&params);
+            let sem_wmc = sem_dnnf.unsmoothed_wmc(&params);
 
             let eps = f64::abs(std_wmc.0 - sem_wmc.0) < 0.0001;
             if !eps {
@@ -1174,7 +1173,7 @@ mod test_dnnf_builder {
             let std_builder = StandardDecisionNNFBuilder::new(order.clone());
             let std_dnnf = std_builder.compile_cnf_topdown(&cnf);
 
-            let sem_builder = SemanticDecisionNNFBuilder::<{primes::U64_LARGEST}>::new(order.clone());
+            let sem_builder = SemanticDecisionNNFBuilder::<{primes::U64_LARGEST}>::new(order);
             let sem_dnnf = sem_builder.compile_cnf_topdown(&cnf);
 
 
@@ -1182,8 +1181,8 @@ mod test_dnnf_builder {
                 (0..cnf.num_vars()).map(|x| (VarLabel::new(x as u64), (RealSemiring(0.3), RealSemiring(0.7)))));
             let params = WmcParams::new(weight_map);
 
-            let std_wmc = std_dnnf.unsmoothed_wmc(&order, &params);
-            let sem_wmc = sem_dnnf.unsmoothed_wmc(&order, &params);
+            let std_wmc = std_dnnf.unsmoothed_wmc(&params);
+            let sem_wmc = sem_dnnf.unsmoothed_wmc(&params);
 
             let eps = f64::abs(std_wmc.0 - sem_wmc.0) < 0.0001;
             if !eps {


### PR DESCRIPTION
We never use this parameter, and this significantly simplifies:

- FFI boundaries (why I originally was looking at this)
- the API overall!

~~Will have to ask Steven about why `Order` exists (I assume potentially for smoothing?). Could be interesting to then implement Arthur & co's smoothing decomposable circuits generically on the `DDNNFPtr`.~~

At a later point, we could consider re-adding this for a generic smooth operation, but that's pending on me implementing SDD smoothing.