### PR TITLE
Make buildable on Rust 1.63 (downgrade `petgraph`, remove `where` clause on associated type)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustc-hash = "1.1.0"
 bit-set = "0.5.3"
 segment-tree = "2.0.0"
 bumpalo = "3.11.1"
-petgraph = "0.6.2"
+petgraph = "0.5.1"
 rand_chacha = "0.3.1"
 # optional: only used to build [[bin]]
 clap = { version = "4.2.1", features = ["derive"], optional = true }

--- a/src/repr/sdd/sdd_or.rs
+++ b/src/repr/sdd/sdd_or.rs
@@ -165,7 +165,7 @@ impl<'a> SddNodeIter<'a> {
 }
 
 impl<'a> Iterator for SddNodeIter<'a> {
-    type Item = SddAnd<'a> where Self: 'a;
+    type Item = SddAnd<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.sdd {


### PR DESCRIPTION
This is mostly for the OCaml package CI.