### PR TITLE
Place C bindings behind `ffi` feature flag, add FFI CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,28 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  ffi:
+    name: ffi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cbindgen
+        run: cargo install cbindgen
+      - name: Generate C header file
+        run: cbindgen --config cbindgen.toml --crate rsdd --output rsdd.h
+      - name: Build (with feature flag)
+        run: cargo build --verbose --features="ffi" --release
+      - name: Move sample .c file
+        run: mv scripts/main.c main.c
+      - name: Compile sample .c file
+        run: gcc main.c -o main -lrsdd -L./target/release
+        env:
+          LD_LIBRARY_PATH: "./target/release" # necessary for dynamic linking to resolve
+      - name: Compile sample .c file
+        run: ./main
+        env:
+          LD_LIBRARY_PATH: "./target/release" # necessary for dynamic linking to resolve
+
   wasm:
     name: wasm
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ rpath = false
 
 [features]
 cli = ["clap", "serde_json"]
+ffi = []
 
 [[bin]]
 name = "bottomup_cnf_to_bdd"

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,1 +1,4 @@
 language = "C"
+
+[parse.expand]
+features = ["ffi"] # required to emit FFI (see: lib.rs)

--- a/scripts/main.c
+++ b/scripts/main.c
@@ -1,0 +1,17 @@
+#include "rsdd.h"
+#include <stdio.h>
+
+char* cnf_string =
+"p cnf 6 3\n"
+"1 2 3 4 0\n"
+"-2 -3 4 5 0\n"
+"-4 -5 6 6 0\n";
+
+int main() {
+  VarOrder* order = var_order_linear(6);
+  Cnf* cnf = cnf_from_dimacs(cnf_string);
+  RsddBddBuilder* builder = robdd_builder_all_table(order);
+  BddPtr* bdd = robdd_builder_compile_cnf(builder, cnf);
+  uint64_t mc = robdd_model_count(builder, bdd);
+  printf("Model Count: %llu\n", mc);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,9 @@ pub mod serialize;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
+// added feature flags to prevent double-exporting
+// when using rsdd-ocaml
+#[cfg(feature = "ffi")]
 mod ffi;
+#[cfg(feature = "ffi")]
 pub use self::ffi::*;


### PR DESCRIPTION
Essentially codifies #171 into some CI; this is necessary so that we don't have duplicate symbols with rsdd-ocaml.

(the instructions for #171 still work, *except* you now need to build with the feature flag, i.e. `cargo build --features="ffi"`)