### PR TITLE
Fix unchecked index for Robdd allocator

### DIFF
--- a/src/builder/bdd/robdd.rs
+++ b/src/builder/bdd/robdd.rs
@@ -190,10 +190,12 @@ impl<'a, T: IteTable<'a, BddPtr<'a>> + Default> RobddBuilder<'a, T> {
                 match bdd.scratch::<usize>() {
                     None => (),
                     Some(v) => {
-                        return if bdd.is_neg() {
-                            alloc[v].neg()
-                        } else {
-                            alloc[v]
+                        if alloc.len() > v {
+                            return if bdd.is_neg() {
+                                alloc[v].neg()
+                            } else {
+                                alloc[v]
+                            };
                         }
                     }
                 };


### PR DESCRIPTION
This is a (temporary?) fix for a bug that Madkour flagged. I'm not really sure *why* this bug is only happening now (looking at the git blame, nobody has really touched this logic in a while). Perhaps the scratch is not being cleared properly?

Creating this branch to unblock.