### PR TITLE
wmc in the FFI

### DIFF
--- a/nix/0001-Cargo.lock.patch
+++ b/nix/0001-Cargo.lock.patch
@@ -1,7 +1,7 @@
-From dd65c7178e1bafabbb398d809c2ac68b6918783b Mon Sep 17 00:00:00 2001
+From 617bfa73ace331d0b52b4561350352ce24151bb4 Mon Sep 17 00:00:00 2001
 From: Sam Stites <stites@users.noreply.github.com>
-Date: Sat, 21 Oct 2023 01:31:15 -0400
-Subject: [PATCH] add lock
+Date: Sat, 11 Nov 2023 14:18:18 -0500
+Subject: [PATCH] Cargo.lock
 
 ---
  Cargo.lock | 712 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -10,7 +10,7 @@ Subject: [PATCH] add lock
 
 diff --git a/Cargo.lock b/Cargo.lock
 new file mode 100644
-index 0000000..dd1ea2e
+index 0000000..498128d
 --- /dev/null
 +++ b/Cargo.lock
 @@ -0,0 +1,712 @@
@@ -116,9 +116,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "clap"
-+version = "4.4.6"
++version = "4.4.8"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
++checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 +dependencies = [
 + "clap_builder",
 + "clap_derive",
@@ -126,9 +126,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "clap_builder"
-+version = "4.4.6"
++version = "4.4.8"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
++checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 +dependencies = [
 + "anstream",
 + "anstyle",
@@ -138,9 +138,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "clap_derive"
-+version = "4.4.2"
++version = "4.4.7"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
++checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 +dependencies = [
 + "heck",
 + "proc-macro2",
@@ -150,9 +150,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "clap_lex"
-+version = "0.5.1"
++version = "0.6.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
++checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 +
 +[[package]]
 +name = "colorchoice"
@@ -187,9 +187,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "getrandom"
-+version = "0.2.10"
++version = "0.2.11"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
++checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 +dependencies = [
 + "cfg-if",
 + "js-sys",
@@ -234,18 +234,18 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "js-sys"
-+version = "0.3.64"
++version = "0.3.65"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
++checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 +dependencies = [
 + "wasm-bindgen",
 +]
 +
 +[[package]]
 +name = "libc"
-+version = "0.2.149"
++version = "0.2.150"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
++checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 +
 +[[package]]
 +name = "log"
@@ -426,9 +426,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "rational"
-+version = "1.4.0"
++version = "1.5.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "39389faa4d1b280fdcadef3b77a03d6d80d3ca9f88fc1ba29e926aea515761d4"
++checksum = "04cb5b80a07a398dd9368df8c2e8ae1be87d960a9a64a8c2a2f7996bf7ce4fac"
 +
 +[[package]]
 +name = "regex"
@@ -504,9 +504,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "serde"
-+version = "1.0.189"
++version = "1.0.192"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
++checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 +dependencies = [
 + "serde_derive",
 +]
@@ -524,9 +524,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "serde_derive"
-+version = "1.0.189"
++version = "1.0.192"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
++checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 +dependencies = [
 + "proc-macro2",
 + "quote",
@@ -535,9 +535,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "serde_json"
-+version = "1.0.107"
++version = "1.0.108"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
++checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 +dependencies = [
 + "itoa",
 + "ryu",
@@ -556,9 +556,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "smallvec"
-+version = "1.11.1"
++version = "1.11.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
++checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 +
 +[[package]]
 +name = "strsim"
@@ -568,9 +568,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "syn"
-+version = "2.0.38"
++version = "2.0.39"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
++checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 +dependencies = [
 + "proc-macro2",
 + "quote",
@@ -609,9 +609,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "wasm-bindgen"
-+version = "0.2.87"
++version = "0.2.88"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
++checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 +dependencies = [
 + "cfg-if",
 + "wasm-bindgen-macro",
@@ -619,9 +619,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "wasm-bindgen-backend"
-+version = "0.2.87"
++version = "0.2.88"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
++checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 +dependencies = [
 + "bumpalo",
 + "log",
@@ -634,9 +634,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "wasm-bindgen-macro"
-+version = "0.2.87"
++version = "0.2.88"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
++checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 +dependencies = [
 + "quote",
 + "wasm-bindgen-macro-support",
@@ -644,9 +644,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "wasm-bindgen-macro-support"
-+version = "0.2.87"
++version = "0.2.88"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
++checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 +dependencies = [
 + "proc-macro2",
 + "quote",
@@ -657,9 +657,9 @@ index 0000000..dd1ea2e
 +
 +[[package]]
 +name = "wasm-bindgen-shared"
-+version = "0.2.87"
++version = "0.2.88"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
++checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 +
 +[[package]]
 +name = "windows-sys"
@@ -728,4 +728,5 @@ index 0000000..dd1ea2e
 +checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 -- 
 2.42.0
+
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,22 +5,18 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "rsdd";
-  version = "0.1.0";
+  version = "unstable-2023-11-11";
 
   src = ../.;
 
-  #cargoHash = "sha256-GYO554P3VHilJm2z/BM8noiPKG/HQM5jSELwuXAHJAA=";
-  cargoHash = "sha256-dl1R1VHPPwa2RVZw3as7zbmKUSrWvjTrMYn/YEYw/38=";
-
   cargoPatches = [./0001-Cargo.lock.patch];
-
-
-  buildFeatures = [ "ffi" "cli" ];
+  cargoHash = "sha256-yIGvJRSW1qCf4giVZkj2rW7g0CG69nd5Ystle6cG5nU=";
+  buildFeatures = [ "ffi" ];
 
   meta = with lib; {
     description = "Rust decision diagrams";
     homepage = "https://github.com/neuppl/rsdd";
     license = licenses.mit;
-    maintainers = with maintainers; [ stites ];
+    maintainers = with maintainers; [];
   };
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1697058441,
-        "narHash": "sha256-gjtW+nkM9suMsjyid63HPmt6WZQEvuVqA5cOAf4lLM0=",
+        "lastModified": 1702045862,
+        "narHash": "sha256-Cfey2TztpW9zCzW9OI/xTWQw+tkZjRZ0K9iRM2bNALk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "55294461a62d90c8626feca22f52b0d3d0e18e39",
+        "rev": "2ff5c8bda714a0a78c11e4402bfb6dabeeddc582",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697723726,
-        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "lastModified": 1701718080,
+        "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "rev": "2c7f3c0fb7c08a0814627611d9d7d45ab6d75335",
         "type": "github"
       },
       "original": {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -101,6 +101,7 @@ pub unsafe extern "C" fn mk_bdd_manager_default_order(num_vars: u64) -> *mut Rsd
     .cast()
 }
 
+
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bdd_new_label(builder: *mut RsddBddBuilder) -> u64 {
@@ -117,6 +118,17 @@ pub unsafe extern "C" fn bdd_var(
 ) -> *mut BddPtr<'static> {
     let builder = robdd_builder_from_ptr(builder);
     let ptr = builder.var(VarLabel::new(label), polarity);
+    Box::into_raw(Box::new(ptr))
+}
+
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn bdd_new_var(
+    builder: *mut RsddBddBuilder,
+    polarity: bool,
+) -> *mut BddPtr<'static> {
+    let builder = robdd_builder_from_ptr(builder);
+    let (_, ptr) = builder.new_var(polarity);
     Box::into_raw(Box::new(ptr))
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -101,7 +101,6 @@ pub unsafe extern "C" fn mk_bdd_manager_default_order(num_vars: u64) -> *mut Rsd
     .cast()
 }
 
-
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn bdd_new_label(builder: *mut RsddBddBuilder) -> u64 {

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -6,6 +6,7 @@ use core::fmt::Debug;
 use std::collections::HashMap;
 /// Weighted model counting parameters for a BDD. It primarily is a storage for
 /// the weight on each variable.
+#[repr(C)]
 #[derive(Clone)]
 pub struct WmcParams<T: Semiring> {
     pub zero: T,


### PR DESCRIPTION
breaks rsdd-ocaml since I've removed `bdd_new_var`. Happy to add it back, but I think the FFI library should be responsible for the sugar that new_var was intended to provide.