### PR TITLE
add JSON serialization to FFI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ rpath = false
 
 [features]
 cli = ["clap", "serde_json"]
-ffi = []
+ffi = ["serde_json"]
 
 [[bin]]
 name = "bottomup_cnf_to_bdd"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -7,6 +7,7 @@ use crate::{
     builder::{bdd::RobddBuilder, cache::AllIteTable, BottomUpBuilder},
     constants::primes,
     repr::{BddPtr, Cnf, VarLabel, VarOrder, WmcParams},
+    serialize::{BDDSerializer},
     util::semirings::FiniteField,
 };
 
@@ -251,6 +252,17 @@ pub unsafe extern "C" fn print_bdd(bdd: *mut BddPtr<'static>) -> *const c_char {
     let s = std::ffi::CString::new((*bdd).print_bdd()).unwrap();
     let p = s.as_ptr();
     std::mem::forget(s);
+    p
+}
+
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn bdd_to_json(bdd: *mut BddPtr<'static>) -> *const c_char {
+    let json = BDDSerializer::from_bdd(*bdd);
+    let str = serde_json::to_string(&json).unwrap();
+    let cstr = std::ffi::CString::new(str).unwrap();
+    let p = cstr.as_ptr();
+    std::mem::forget(cstr);
     p
 }
 


### PR DESCRIPTION
Exposing JSON serialization through the FFI allows me to get BDD visualizations into Roulette. Hopefully this will help us debug performance problems.